### PR TITLE
Torrent notifications

### DIFF
--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.VIBRATE"/>
 
     <!-- https://developer.android.com/training/basics/intents/package-visibility -->
     <queries>

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/base/UnchainedApplication.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/base/UnchainedApplication.kt
@@ -1,8 +1,11 @@
 package com.github.livingwithhippos.unchained.base
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
+import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import com.github.livingwithhippos.unchained.R
 import com.github.livingwithhippos.unchained.data.repositoy.CredentialsRepository
@@ -44,5 +47,29 @@ class UnchainedApplication : Application() {
             nightModeArray[1] -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
             nightModeArray[2] -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
         }
+
+        createNotificationChannel()
     }
+
+    private fun createNotificationChannel() {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = getString(R.string.app_name)
+            val descriptionText = getString(R.string.torrent_channel_description)
+            val importance = NotificationManager.IMPORTANCE_LOW
+            val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
+                description = descriptionText
+            }
+            // Register the channel with the system
+            val notificationManager: NotificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val CHANNEL_ID = "unchained_torrent_channel"
+    }
+
 }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/di/NotificationModule.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/di/NotificationModule.kt
@@ -1,0 +1,31 @@
+package com.github.livingwithhippos.unchained.di
+
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import com.github.livingwithhippos.unchained.R
+import com.github.livingwithhippos.unchained.base.UnchainedApplication
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Singleton
+
+@InstallIn(ApplicationComponent::class)
+@Module
+object NotificationModule {
+
+    private const val GROUP_KEY_TORRENTS: String = "group_key_torrent"
+
+    @Provides
+    @Singleton
+    fun provideNotificationBuilder(@ApplicationContext appContext: Context): NotificationCompat.Builder {
+        // fixme: using the logo from R.mipmap.icon_launcher gives a painted icon, this one does not. Maybe because this is missing a background?
+        return NotificationCompat.Builder(appContext, UnchainedApplication.CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_logo_no_bg)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setGroup(GROUP_KEY_TORRENTS)
+
+    }
+
+}

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/view/TorrentDetailsFragment.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/view/TorrentDetailsFragment.kt
@@ -213,6 +213,8 @@ class TorrentDetailsFragment : UnchainedFragment(), TorrentDetailsListener {
                     .setPriority(NotificationCompat.PRIORITY_HIGH)
                 notify(id, builder.build())
             }
+
+            context?.vibrate()
         }
     }
 

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/view/TorrentDetailsFragment.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/view/TorrentDetailsFragment.kt
@@ -51,26 +51,6 @@ class TorrentDetailsFragment : UnchainedFragment(), TorrentDetailsListener {
     )
 
     private lateinit var builder: NotificationCompat.Builder
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setHasOptionsMenu(true)
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.torrent_details_bar, menu)
-        super.onCreateOptionsMenu(menu, inflater)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.delete -> {
-                val dialog = DeleteDialogFragment()
-                dialog.show(parentFragmentManager, "DeleteDialogFragment")
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -180,6 +160,27 @@ class TorrentDetailsFragment : UnchainedFragment(), TorrentDetailsListener {
         })
 
         return torrentBinding.root
+    }
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.torrent_details_bar, menu)
+        super.onCreateOptionsMenu(menu, inflater)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.delete -> {
+                val dialog = DeleteDialogFragment()
+                dialog.show(parentFragmentManager, "DeleteDialogFragment")
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     private fun updateNotificationText(id: String, fileName: String) {

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/viewmodel/TorrentDetailsViewModel.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/viewmodel/TorrentDetailsViewModel.kt
@@ -27,6 +27,7 @@ class TorrentDetailsViewModel @ViewModelInject constructor(
     val downloadLiveData = MutableLiveData<Event<DownloadItem?>>()
 
 
+    // todo: move this and the rest of the notification stuff to MainActivity so it works outside the details fragment
     fun fetchTorrentDetails(torrentID: String) {
         viewModelScope.launch {
             val token = getToken()

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/extension/Extension.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/extension/Extension.kt
@@ -8,6 +8,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
 import android.net.Uri
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
 import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -169,5 +172,14 @@ fun AppCompatActivity.setCustomTheme(theme: String) {
     when (theme) {
         "original" -> setTheme(R.style.Theme_Unchained)
         "tropical_sunset" -> setTheme(R.style.Theme_Unchained_TropicalSunset)
+    }
+}
+
+fun Context.vibrate(duration: Long = 200){
+    val vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        vibrator.vibrate(VibrationEffect.createOneShot(duration, VibrationEffect.DEFAULT_AMPLITUDE))
+    } else {
+        vibrator.vibrate(duration)
     }
 }

--- a/app/app/src/main/res/drawable/ic_logo_no_bg.xml
+++ b/app/app/src/main/res/drawable/ic_logo_no_bg.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="15.08125dp"
+    android:height="15.08125dp"
+    android:viewportWidth="15.08125"
+    android:viewportHeight="15.081251">
+  <path
+      android:pathData="M6.7884,6.835 L4.5488,8.5646"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="0.792503"
+      android:fillColor="#00000000"
+      android:strokeColor="#ff6b58"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="m4.1167,7.9239c-0.5476,0 -0.9941,0.4495 -0.9941,0.9979 0,0.5496 0.4464,0.9998 0.9941,0.9998 0.5477,0 0.996,-0.4499 0.996,-0.9998 0,-0.5487 -0.4483,-0.9979 -0.996,-0.9979zM4.1167,8.5646c0.1976,0 0.3572,0.1587 0.3572,0.3572 0,0.1985 -0.1601,0.3591 -0.3572,0.3591 -0.1969,0 -0.3553,-0.1601 -0.3553,-0.3591 0,-0.199 0.1578,-0.3572 0.3553,-0.3572z"
+      android:strokeWidth="2.34631"
+      android:fillColor="#f8b660"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="M8.5075,8.9199A3.3593,3.3593 0,0 1,5.4069 12.2692,3.3593 3.3593,0 0,1 1.8287,9.4358 3.3593,3.3593 0,0 1,4.3782 5.65"
+      android:strokeWidth="1.27149"
+      android:fillColor="#00000000"
+      android:strokeColor="#d20076"/>
+  <path
+      android:pathData="m6.5737,6.1613a3.3593,3.3593 0,0 1,3.1006 -3.3493,3.3593 3.3593,0 0,1 3.5782,2.8335 3.3593,3.3593 0,0 1,-2.5495 3.7858"
+      android:strokeWidth="1.27149"
+      android:fillColor="#00000000"
+      android:strokeColor="#ff4373"/>
+  <path
+      android:pathData="M4.7212,3.6897 L10.8871,12.1079"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1.27149"
+      android:fillColor="#00000000"
+      android:strokeColor="#f8b660"
+      android:strokeLineCap="butt"/>
+</vector>

--- a/app/app/src/main/res/layout/fragment_torrent_details.xml
+++ b/app/app/src/main/res/layout/fragment_torrent_details.xml
@@ -56,7 +56,7 @@
             android:checkable="false"
             android:clickable="false"
             android:focusable="true"
-            app:cardElevation="0dp"
+            app:cardElevation="5dp"
             app:cardCornerRadius="10dp"
             app:strokeColor="@color/grey_01"
             app:strokeWidth="0.05dp"
@@ -65,7 +65,7 @@
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:padding="25dp">
+                android:padding="20dp">
 
                 <TextView
                     android:id="@+id/tvStatusTitle"
@@ -130,7 +130,7 @@
             android:checkable="false"
             android:clickable="false"
             android:focusable="true"
-            app:cardElevation="0dp"
+            app:cardElevation="3dp"
             app:cardCornerRadius="10dp"
             app:strokeColor="@color/grey_01"
             app:strokeWidth="0.05dp"

--- a/app/app/src/main/res/values-it/strings.xml
+++ b/app/app/src/main/res/values-it/strings.xml
@@ -185,4 +185,8 @@
     <string name="open_link_format">Apri link %1$s</string>
     <string name="copy_link_format">Copia link %1$s</string>
     <string name="open_with_format">Apri %1$s con Yatse</string>
+    <string name="torrent_channel_description">Canale per gestire le notificeh di download dei torrent</string>
+    <string name="torrent_in_progress">Download torrent in corso</string>
+    <string name="torrent_in_progress_format">%1$d%% - Download in corso</string>
+    <string name="download_complete">Download completato</string>
 </resources>

--- a/app/app/src/main/res/values-it/strings.xml
+++ b/app/app/src/main/res/values-it/strings.xml
@@ -189,4 +189,5 @@
     <string name="torrent_in_progress">Download torrent in corso</string>
     <string name="torrent_in_progress_format">%1$d%% - Download in corso</string>
     <string name="download_complete">Download completato</string>
+    <string name="status_unknown">Stato sconosciuto</string>
 </resources>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -405,4 +405,5 @@
     <string name="torrent_in_progress">Torrent download in progress</string>
     <string name="torrent_in_progress_format">%1$d%% - Download in progress</string>
     <string name="download_complete">Download complete</string>
+    <string name="status_unknown">Uknown Status</string>
 </resources>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -401,4 +401,8 @@
     <string name="copy_link_format">Copy %1$s link </string>
     <string name="open_with_format">Open %1$s with Yatse</string>
     <string name="yatse" translatable="false">Yatse</string>
+    <string name="torrent_channel_description">Channel to manage torrents download notification</string>
+    <string name="torrent_in_progress">Torrent download in progress</string>
+    <string name="torrent_in_progress_format">%1$d%% - Download in progress</string>
+    <string name="download_complete">Download complete</string>
 </resources>

--- a/extra_assets/graphics/logo_no_bg.svg
+++ b/extra_assets/graphics/logo_no_bg.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="logo_no_bg.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg307"
+   version="1.1"
+   viewBox="0 0 15.08125 15.081251"
+   height="15.08125mm"
+   width="15.08125mm">
+  <defs
+     id="defs301" />
+  <sodipodi:namedview
+     inkscape:window-maximized="0"
+     inkscape:window-y="0"
+     inkscape:window-x="532"
+     inkscape:window-height="2054"
+     inkscape:window-width="1918"
+     showgrid="false"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="32.993151"
+     inkscape:cx="28.674688"
+     inkscape:zoom="16"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     units="mm" />
+  <metadata
+     id="metadata304">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Livello 1">
+    <path
+       style="fill:none;stroke:#ff6b58;stroke-width:0.792503;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 6.7883696,6.8349821 4.5487827,8.5646115"
+       id="path1469" />
+    <path
+       id="path302-7-6"
+       style="fill:#f8b660;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.34631;stroke-miterlimit:4;stroke-dasharray:none"
+       sodipodi:type="inkscape:offset"
+       inkscape:radius="0.11066051"
+       inkscape:original="M 4.2011719 5.7890625 C 3.6954473 5.7890625 3.2851562 6.2019719 3.2851562 6.7089844 C 3.2851562 7.2174535 3.6954473 7.6308594 4.2011719 7.6308594 C 4.7068953 7.6308594 5.1191406 7.2174535 5.1191406 6.7089844 C 5.1191406 6.2019719 4.7068953 5.7890625 4.2011719 5.7890625 z M 4.2011719 6.2285156 C 4.4654917 6.2285156 4.6816406 6.4437587 4.6816406 6.7089844 C 4.6816406 6.9742066 4.4654917 7.1914062 4.2011719 7.1914062 C 3.9369991 7.1914063 3.7226562 6.9742066 3.7226562 6.7089844 C 3.7226562 6.4437587 3.9369991 6.2285156 4.2011719 6.2285156 z "
+       d="m 4.2011719,5.6777344 c -0.5659587,0 -1.0273438,0.4645374 -1.0273438,1.03125 0,0.5679981 0.4613127,1.0332031 1.0273438,1.0332031 0.56603,0 1.0292969,-0.4649214 1.0292969,-1.0332031 0,-0.5669969 -0.4633393,-1.03125 -1.0292969,-1.03125 z m 0,0.6621094 c 0.2042438,0 0.3691406,0.1640376 0.3691406,0.3691406 0,0.2050986 -0.1654429,0.3710937 -0.3691406,0.3710937 -0.203517,1e-7 -0.3671875,-0.1654927 -0.3671875,-0.3710937 0,-0.2056053 0.1631241,-0.3691406 0.3671875,-0.3691406 z"
+       transform="matrix(0.96764737,0,0,0.96764737,0.05149056,2.4298783)" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#d20076;stroke-width:1.27149;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path844"
+       sodipodi:type="arc"
+       sodipodi:cx="5.1482029"
+       sodipodi:cy="8.9199085"
+       sodipodi:rx="3.3593161"
+       sodipodi:ry="3.3593161"
+       sodipodi:start="0"
+       sodipodi:end="4.4811254"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       d="M 8.507519,8.9199085 A 3.3593161,3.3593161 0 0 1 5.406909,12.269248 3.3593161,3.3593161 0 0 1 1.8287335,9.4357841 3.3593161,3.3593161 0 0 1 4.378222,5.6500256" />
+    <path
+       d="m -6.5737312,-6.1613421 a 3.3593161,3.3593161 0 0 1 -3.10061,3.3493396 3.3593161,3.3593161 0 0 1 -3.5781758,-2.8334641 3.3593161,3.3593161 0 0 1 2.549489,-3.7857584"
+       sodipodi:arc-type="arc"
+       sodipodi:open="true"
+       sodipodi:end="4.4811254"
+       sodipodi:start="0"
+       sodipodi:ry="3.3593161"
+       sodipodi:rx="3.3593161"
+       sodipodi:cy="-6.1613421"
+       sodipodi:cx="-9.9330473"
+       sodipodi:type="arc"
+       id="path853"
+       style="fill:none;fill-opacity:1;stroke:#ff4373;stroke-width:1.27149;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="scale(-1)" />
+    <path
+       style="fill:none;stroke:#f8b660;stroke-width:1.27149;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 4.721173,3.6896672 10.887137,12.10792"
+       id="path1422"
+       inkscape:transform-center-x="0.18888555"
+       inkscape:transform-center-y="-0.13162152" />
+  </g>
+</svg>


### PR DESCRIPTION
Notes:

- the notifications will be for all the torrent download items in an active state ("magnet_conversion", "waiting_files_selection", "queued","downloading","compressing", "uploading"), not ended ("magnet_error", "downloaded", "error", "virus", "dead")
- it needs to be managed from the activity so Iit won't stop after moving from the torrent details fragment
- it will be managed by calling the torrent list api and filtering for "active" statuses
- it kinds of overlap with the torrent list livedata
- the torrent details fragment needs to be updated too, to populate its views. It should observe this list from activityViewModel
- notifications will be grouped togheter

Material: 

- https://developer.android.com/training/notify-user/expanded
- https://developer.android.com/training/notify-user/build-notification
- https://developer.android.com/guide/topics/ui/notifiers/notifications