### PR TITLE
Torrent download notifications

### DIFF
--- a/app/app/build.gradle
+++ b/app/app/build.gradle
@@ -185,17 +185,12 @@ dependencies {
     // material design
     implementation "com.google.android.material:material:$material_version"
 
-    // ViewModel
+    // Lifecycle stuff
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
-
-    // LiveData
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
-
-    // extensions
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
-
-    // Saved state module for ViewModel
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-service:$lifecycle_version"
 
     // Annotation processor
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"

--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+
 
     <!-- https://developer.android.com/training/basics/intents/package-visibility -->
     <queries>

--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -159,6 +159,12 @@
             </intent-filter>
         </activity>
 
+        <service
+            android:name="com.github.livingwithhippos.unchained.data.service.ForegroundTorrentService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
         <meta-data
             android:name="preloaded_fonts"
             android:resource="@array/preloaded_fonts" />

--- a/app/app/src/main/AndroidManifest.xml
+++ b/app/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
 
 
     <!-- https://developer.android.com/training/basics/intents/package-visibility -->

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
@@ -13,6 +13,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.viewModels
+import androidx.core.content.ContextCompat
 import androidx.core.view.forEach
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
@@ -23,6 +24,7 @@ import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import com.github.livingwithhippos.unchained.R
 import com.github.livingwithhippos.unchained.data.model.AuthenticationState
+import com.github.livingwithhippos.unchained.data.service.ForegroundTorrentService
 import com.github.livingwithhippos.unchained.databinding.ActivityMainBinding
 import com.github.livingwithhippos.unchained.settings.SettingsActivity
 import com.github.livingwithhippos.unchained.settings.SettingsFragment
@@ -105,6 +107,9 @@ class MainActivity : UnchainedActivity() {
                 // do nothing
                 AuthenticationState.AUTHENTICATED, AuthenticationState.AUTHENTICATED_NO_PREMIUM -> {
                     enableAllBottomNavItems()
+                    // start the notification system
+                    val notificationIntent = Intent(this, ForegroundTorrentService::class.java)
+                    ContextCompat.startForegroundService(this, notificationIntent)
                 }
             }
         })

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
@@ -245,7 +245,15 @@ class MainActivity : UnchainedActivity() {
                     }
                 }
             }
-            null -> { // app opened directly by the user. Do nothing.
+            null -> {
+                // could be because of the tap on a notification
+                intent.getStringExtra(KEY_TORRENT_ID)?.let{id ->
+
+                    viewModel.authenticationState.observeOnce(this, { auth ->
+                        if (auth.peekContent()==AuthenticationState.AUTHENTICATED || auth.peekContent()==AuthenticationState.AUTHENTICATED_NO_PREMIUM)
+                            processTorrentNotificationIntent(id)
+                    })
+                }
             }
             else -> {
 
@@ -256,6 +264,16 @@ class MainActivity : UnchainedActivity() {
     override fun onDestroy() {
         super.onDestroy()
         unregisterReceiver(downloadReceiver)
+    }
+
+    private fun processTorrentNotificationIntent(torrentID: String) {
+        // simulate click on new download tab
+        val bottomNav = findViewById<BottomNavigationView>(R.id.bottom_nav_view)
+        if (bottomNav.selectedItemId != R.id.navigation_new_download) {
+            //todo: check how to double click
+            bottomNav.selectedItemId = R.id.navigation_new_download
+        }
+        viewModel.addTorrentId(torrentID)
     }
 
     private fun processLinkIntent(uri: Uri) {

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.viewModels
@@ -25,9 +26,11 @@ import androidx.navigation.ui.setupActionBarWithNavController
 import com.github.livingwithhippos.unchained.R
 import com.github.livingwithhippos.unchained.data.model.AuthenticationState
 import com.github.livingwithhippos.unchained.data.service.ForegroundTorrentService
+import com.github.livingwithhippos.unchained.data.service.ForegroundTorrentService.Companion.KEY_TORRENT_ID
 import com.github.livingwithhippos.unchained.databinding.ActivityMainBinding
 import com.github.livingwithhippos.unchained.settings.SettingsActivity
 import com.github.livingwithhippos.unchained.settings.SettingsFragment
+import com.github.livingwithhippos.unchained.settings.SettingsFragment.Companion.KEY_TORRENT_NOTIFICATIONS
 import com.github.livingwithhippos.unchained.start.viewmodel.MainActivityViewModel
 import com.github.livingwithhippos.unchained.utilities.SCHEME_HTTP
 import com.github.livingwithhippos.unchained.utilities.SCHEME_HTTPS
@@ -108,7 +111,7 @@ class MainActivity : UnchainedActivity() {
                 AuthenticationState.AUTHENTICATED, AuthenticationState.AUTHENTICATED_NO_PREMIUM -> {
                     enableAllBottomNavItems()
                     // start the notification system if enabled
-                    if (preferences.getBoolean("enable_torrent_notifications", false)) {
+                    if (preferences.getBoolean(KEY_TORRENT_NOTIFICATIONS, false)) {
                         val notificationIntent = Intent(this, ForegroundTorrentService::class.java)
                         ContextCompat.startForegroundService(this, notificationIntent)
                     }
@@ -144,6 +147,18 @@ class MainActivity : UnchainedActivity() {
                 })
             }
         })
+
+        // monitor if the torrent notification service needs to be started. It monitor the preference change itself
+        // for the shutting down part
+        preferences.registerOnSharedPreferenceChangeListener { sharedPreferences, key ->
+            if (key == KEY_TORRENT_NOTIFICATIONS) {
+                val enableTorrentNotifications = sharedPreferences.getBoolean(key, false)
+                if (enableTorrentNotifications) {
+                    val notificationIntent = Intent(this, ForegroundTorrentService::class.java)
+                    ContextCompat.startForegroundService(this, notificationIntent)
+                }
+            }
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
@@ -92,7 +92,7 @@ class MainActivity : UnchainedActivity() {
                 // go to login fragment
                 AuthenticationState.UNAUTHENTICATED -> {
                     openAuthentication()
-                    disableBottomNavItems(R.id.navigation_new_download,R.id.navigation_lists)
+                    disableBottomNavItems(R.id.navigation_new_download, R.id.navigation_lists)
                 }
                 // refresh the token.
                 // todo: if it keeps on being bad (hehe) delete the credentials and start the authentication from zero
@@ -102,14 +102,16 @@ class MainActivity : UnchainedActivity() {
                 // go to login fragment and show another error message
                 AuthenticationState.ACCOUNT_LOCKED -> {
                     openAuthentication()
-                    disableBottomNavItems(R.id.navigation_new_download,R.id.navigation_lists)
+                    disableBottomNavItems(R.id.navigation_new_download, R.id.navigation_lists)
                 }
                 // do nothing
                 AuthenticationState.AUTHENTICATED, AuthenticationState.AUTHENTICATED_NO_PREMIUM -> {
                     enableAllBottomNavItems()
-                    // start the notification system
-                    val notificationIntent = Intent(this, ForegroundTorrentService::class.java)
-                    ContextCompat.startForegroundService(this, notificationIntent)
+                    // start the notification system if enabled
+                    if (preferences.getBoolean("enable_torrent_notifications", false)) {
+                        val notificationIntent = Intent(this, ForegroundTorrentService::class.java)
+                        ContextCompat.startForegroundService(this, notificationIntent)
+                    }
                 }
             }
         })

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/base/UnchainedApplication.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/base/UnchainedApplication.kt
@@ -1,7 +1,11 @@
 package com.github.livingwithhippos.unchained.base
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import com.github.livingwithhippos.unchained.R
 import com.github.livingwithhippos.unchained.data.repositoy.CredentialsRepository
@@ -43,5 +47,28 @@ class UnchainedApplication : Application() {
             nightModeArray[1] -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
             nightModeArray[2] -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
         }
+
+        createNotificationChannel()
     }
+
+    private fun createNotificationChannel() {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = getString(R.string.app_name)
+            val descriptionText = getString(R.string.torrent_channel_description)
+            val importance = NotificationManager.IMPORTANCE_LOW
+            val channel = NotificationChannel(CHANNEL_ID, name, importance).apply {
+                description = descriptionText
+            }
+            // Register the channel with the system
+            val notificationManager: NotificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+        companion object {
+            const val CHANNEL_ID = "unchained_torrent_channel"
+        }
 }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/repositoy/TorrentsRepository.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/repositoy/TorrentsRepository.kt
@@ -94,7 +94,7 @@ class TorrentsRepository @Inject constructor(private val torrentApiHelper: Torre
 
     suspend fun getTorrentsList(
         token: String,
-        offset: Int?,
+        offset: Int? = null,
         page: Int? = 1,
         limit: Int? = 10,
         filter: String? = null

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Binder
 import android.os.IBinder
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.LifecycleService
@@ -52,7 +51,6 @@ class ForegroundTorrentService : LifecycleService() {
     lateinit var preferences: SharedPreferences
 
     private var updateTiming = UPDATE_TIMING_SHORT
-
 
 
     override fun onBind(intent: Intent): IBinder? {
@@ -152,11 +150,21 @@ class ForegroundTorrentService : LifecycleService() {
 
         val notifications = mutableListOf<Notification>()
         items.forEach { torrent ->
-            torrentBuilder.setContentText(torrent.filename)
+            torrentBuilder.setStyle(
+                NotificationCompat.BigTextStyle()
+                    .bigText(torrent.filename)
+            )
+
             if (torrent.status == "downloading") {
                 val speedMBs = (torrent.speed ?: 0).toFloat().div(1000000)
                 torrentBuilder.setProgress(100, torrent.progress, false)
-                    .setContentTitle(getString(R.string.torrent_in_progress_format, torrent.progress, speedMBs))
+                    .setContentTitle(
+                        getString(
+                            R.string.torrent_in_progress_format,
+                            torrent.progress,
+                            speedMBs
+                        )
+                    )
             } else {
                 torrentBuilder.setContentTitle(torrent.status)
                     // note: this could be indeterminate = true since it's technically in a loading status which should change
@@ -193,6 +201,6 @@ class ForegroundTorrentService : LifecycleService() {
         const val KEY_OBSERVED_TORRENTS: String = "observed_torrents_key"
         const val UPDATE_TIMING_SHORT: Long = 5000
         const val UPDATE_TIMING_LONG: Long = 30000
-        const val SUMMARY_ID : Int = 21
+        const val SUMMARY_ID: Int = 21
     }
 }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -206,12 +206,25 @@ class ForegroundTorrentService : LifecycleService() {
     }
 
     private fun completeNotification(item: TorrentItem) {
+        val resultIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            putExtra(KEY_TORRENT_ID, item.id)
+        }
+
+        val resultPendingIntent: PendingIntent? = TaskStackBuilder.create(this).run {
+            // Add the intent, which inflates the back stack
+            addNextIntentWithParentStack(resultIntent)
+            // Get the PendingIntent containing the entire back stack
+            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
+
         notificationManager.apply {
             torrentBuilder.setContentTitle(applicationContext.getStatusTranslation(item.status))
                 // if the file is already downloaded the second row will not be set elsewhere
                 .setContentText(item.filename)
                 // remove the progressbar if present
                 .setProgress(0, 0, false)
+                .setContentIntent(resultPendingIntent)
             notify(item.id.hashCode(), torrentBuilder.build())
         }
     }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -188,11 +188,27 @@ class ForegroundTorrentService : LifecycleService() {
                     // note: this could be indeterminate = true since it's technically in a loading status which should change
                     .setProgress(0, 0, false)
             }
+
+
+            val resultIntent = Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                putExtra(KEY_TORRENT_ID, torrent.id)
+            }
+
+            val resultPendingIntent: PendingIntent? = TaskStackBuilder.create(this).run {
+                // Add the intent, which inflates the back stack
+                addNextIntentWithParentStack(resultIntent)
+                // Get the PendingIntent containing the entire back stack
+                getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)
+            }
+
+            torrentBuilder.setContentIntent(resultPendingIntent)
+
             notifications.add(
                 torrentBuilder.build()
             )
         }
-
+        // will open the app on the torrent details page
         summaryBuilder.setContentText(getString(R.string.downloading_torrent_format, items.size))
 
         notificationManager.apply {
@@ -206,25 +222,12 @@ class ForegroundTorrentService : LifecycleService() {
     }
 
     private fun completeNotification(item: TorrentItem) {
-        val resultIntent = Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            putExtra(KEY_TORRENT_ID, item.id)
-        }
-
-        val resultPendingIntent: PendingIntent? = TaskStackBuilder.create(this).run {
-            // Add the intent, which inflates the back stack
-            addNextIntentWithParentStack(resultIntent)
-            // Get the PendingIntent containing the entire back stack
-            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT)
-        }
-
         notificationManager.apply {
             torrentBuilder.setContentTitle(applicationContext.getStatusTranslation(item.status))
                 // if the file is already downloaded the second row will not be set elsewhere
                 .setContentText(item.filename)
                 // remove the progressbar if present
                 .setProgress(0, 0, false)
-                .setContentIntent(resultPendingIntent)
             notify(item.id.hashCode(), torrentBuilder.build())
         }
     }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -125,7 +125,7 @@ class ForegroundTorrentService : LifecycleService() {
 
         })
 
-        startForeground(CHANNEL_ID.hashCode(), summaryBuilder.build())
+        startForeground(SUMMARY_ID, summaryBuilder.build())
 
     }
 
@@ -174,6 +174,8 @@ class ForegroundTorrentService : LifecycleService() {
                 torrentBuilder.build()
             )
         }
+        
+        summaryBuilder.setContentText(getString(R.string.downloading_torrent_format, items.size))
 
         notificationManager.apply {
             notifications.forEachIndexed { index, notification ->

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Binder
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.LifecycleService
@@ -153,8 +154,9 @@ class ForegroundTorrentService : LifecycleService() {
         items.forEach { torrent ->
             torrentBuilder.setContentText(torrent.filename)
             if (torrent.status == "downloading") {
+                val speedMBs = (torrent.speed ?: 0).toFloat().div(1000000)
                 torrentBuilder.setProgress(100, torrent.progress, false)
-                    .setContentTitle(getString(R.string.torrent_in_progress_format, torrent.progress))
+                    .setContentTitle(getString(R.string.torrent_in_progress_format, torrent.progress, speedMBs))
             } else {
                 torrentBuilder.setContentTitle(torrent.status)
                     // note: this could be indeterminate = true since it's technically in a loading status which should change
@@ -164,8 +166,6 @@ class ForegroundTorrentService : LifecycleService() {
                 torrentBuilder.build()
             )
         }
-
-        summaryBuilder.setContentText(getString(R.string.downloading_torrent_format, items.size))
 
         notificationManager.apply {
             notifications.forEachIndexed { index, notification ->

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -230,7 +230,6 @@ class ForegroundTorrentService : LifecycleService() {
             getPendingIntent( item.id.hashCode(), PendingIntent.FLAG_UPDATE_CURRENT)
         }
 
-        // fixme: viene cancellata la notifica sbagliata con setAutoCancel
         notificationManager.apply {
             torrentBuilder.setContentTitle(applicationContext.getStatusTranslation(item.status))
                 // if the file is already downloaded the second row will not be set elsewhere
@@ -248,7 +247,7 @@ class ForegroundTorrentService : LifecycleService() {
         }
     }
 
-    fun stopTorrentService() {
+    private fun stopTorrentService() {
         stopSelf()
     }
 

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -228,6 +228,8 @@ class ForegroundTorrentService : LifecycleService() {
                 .setContentText(item.filename)
                 // remove the progressbar if present
                 .setProgress(0, 0, false)
+                // remove notification on tap
+                .setAutoCancel(true)
             notify(item.id.hashCode(), torrentBuilder.build())
         }
     }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -11,12 +11,12 @@ import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.lifecycleScope
 import com.github.livingwithhippos.unchained.R
-import com.github.livingwithhippos.unchained.base.UnchainedApplication.Companion.CHANNEL_ID
 import com.github.livingwithhippos.unchained.data.model.TorrentItem
 import com.github.livingwithhippos.unchained.data.repositoy.CredentialsRepository
 import com.github.livingwithhippos.unchained.data.repositoy.TorrentsRepository
 import com.github.livingwithhippos.unchained.di.SummaryNotification
 import com.github.livingwithhippos.unchained.di.TorrentNotification
+import com.github.livingwithhippos.unchained.utilities.extension.getStatusTranslation
 import com.github.livingwithhippos.unchained.utilities.loadingStatusList
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -166,7 +166,7 @@ class ForegroundTorrentService : LifecycleService() {
                         )
                     )
             } else {
-                torrentBuilder.setContentTitle(torrent.status)
+                torrentBuilder.setContentTitle(applicationContext.getStatusTranslation(torrent.status))
                     // note: this could be indeterminate = true since it's technically in a loading status which should change
                     .setProgress(0, 0, false)
             }
@@ -174,7 +174,7 @@ class ForegroundTorrentService : LifecycleService() {
                 torrentBuilder.build()
             )
         }
-        
+
         summaryBuilder.setContentText(getString(R.string.downloading_torrent_format, items.size))
 
         notificationManager.apply {
@@ -189,7 +189,7 @@ class ForegroundTorrentService : LifecycleService() {
 
     private fun completeNotification(item: TorrentItem) {
         notificationManager.apply {
-            torrentBuilder.setContentTitle(item.status)
+            torrentBuilder.setContentTitle(applicationContext.getStatusTranslation(item.status))
                 // if the file is already downloaded the second row will not be set elsewhere
                 .setContentText(item.filename)
                 // remove the progressbar if present

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -1,0 +1,162 @@
+package com.github.livingwithhippos.unchained.data.service
+
+import android.content.Intent
+import android.content.SharedPreferences
+import android.os.Binder
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.LifecycleService
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.lifecycleScope
+import com.github.livingwithhippos.unchained.R
+import com.github.livingwithhippos.unchained.data.model.TorrentItem
+import com.github.livingwithhippos.unchained.data.repositoy.CredentialsRepository
+import com.github.livingwithhippos.unchained.data.repositoy.TorrentsRepository
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class ForegroundTorrentService : LifecycleService() {
+
+    @Inject
+    lateinit var torrentRepository: TorrentsRepository
+
+    @Inject
+    lateinit var credentialsRepository: CredentialsRepository
+
+    private val torrentBinder = Binder()
+
+    private val torrentsLiveData = MutableLiveData<List<TorrentItem>>()
+
+    @Inject
+    lateinit var builder: NotificationCompat.Builder
+
+    @Inject
+    lateinit var notificationManager: NotificationManagerCompat
+
+    @Inject
+    lateinit var preferences: SharedPreferences
+
+    // possible status are magnet_error, magnet_conversion, waiting_files_selection,
+    // queued, downloading, downloaded, error, virus, compressing, uploading, dead
+    private val loadingStatusList = listOf(
+        "downloading",
+        "magnet_conversion",
+        "waiting_files_selection",
+        "queued",
+        "compressing",
+        "uploading"
+    )
+
+    override fun onBind(intent: Intent): IBinder? {
+        super.onBind(intent)
+        return torrentBinder
+    }
+
+    /**
+     * Binder for the client. It can be used to retrieve this service and call its public methods.
+     */
+    inner class TorrentServiceBinder : Binder() {
+        internal val service: ForegroundTorrentService
+            get() = this@ForegroundTorrentService
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        torrentsLiveData.observe(this, { list ->
+
+            // the torrents we were observing
+            val oldTorrentsIDs: Set<String> =
+                preferences.getStringSet(KEY_OBSERVED_TORRENTS, emptySet()) as Set<String>
+            // their updated status
+            val newLoadingTorrents =
+                list.filter { torrent -> loadingStatusList.contains(torrent.status) }
+            // the new torrents to add to the notification system
+            val unwatchedTorrents = newLoadingTorrents.filter { !oldTorrentsIDs.contains(it.id) }
+            // the torrent whose status is not a loading one anymore.
+            //todo: vibrate once if this is not empty
+            val finishedTorrents = list
+                // They are in our old list
+                .filter { oldTorrentsIDs.contains(it.id) }
+                // They aren't in our new loading list
+                .filter { !newLoadingTorrents.map { newT -> newT.id }.contains(it.id) }
+            // the torrents not in our updated list anymore. These needs to be retrieved and analyzed singularly.
+            // Should't happen often since there is a limit on how many active torrents you can have in real debrid
+            // and we retrieve the last 30 torrents every time
+            val missingTorrents = oldTorrentsIDs.filter { id ->
+                !list.map { it.id }.contains(id)
+            }
+
+            // update the torrents id to observe
+            val newIDs = mutableSetOf<String>()
+            newIDs.addAll(newLoadingTorrents.map { it.id })
+            with(preferences.edit()) {
+                putStringSet(KEY_OBSERVED_TORRENTS, newIDs)
+                apply()
+            }
+
+            // let's first operate as if all the needed torrents were always in the list
+
+            // update the notifications for torrents in one of the loading statuses
+            newLoadingTorrents.forEach { torrent ->
+                updateNotification(torrent)
+            }
+            // update the notifications for torrents in one of the finished statuses
+            finishedTorrents.forEach { torrent ->
+                completeNotification(torrent)
+            }
+
+        })
+
+        lifecycleScope.launch {
+
+            while ((preferences.getStringSet(
+                    KEY_OBSERVED_TORRENTS,
+                    emptySet()
+                ) as Set<String>).size > 0
+            ) {
+                // todo: manage token values
+                val token = credentialsRepository.getToken()
+                val torrents = torrentRepository.getTorrentsList(token, limit = 30)
+                torrentsLiveData.postValue(torrents)
+                // update notifications every 5 seconds
+                delay(5000)
+            }
+        }
+    }
+
+    private fun updateNotification(item: TorrentItem) {
+        notificationManager.apply {
+            builder.setContentText(item.filename)
+            if (item.status == "downloading") {
+                builder.setProgress(100, item.progress, false)
+                    .setContentTitle(getString(R.string.torrent_in_progress_format, item.progress))
+            } else {
+                builder.setContentTitle(item.status)
+                    // note: this could be indeterminate = true since it's technically in a loading status which should change
+                    .setProgress(0, 0, false)
+            }
+            notify(item.id.hashCode(), builder.build())
+        }
+    }
+
+    private fun completeNotification(item: TorrentItem) {
+        notificationManager.apply {
+            builder.setContentTitle(item.status)
+                // if the file is already downloaded the second row will not be set elsewhere
+                .setContentText(item.filename)
+                // remove the progressbar if present
+                .setProgress(0, 0, false)
+            notify(item.id.hashCode(), builder.build())
+        }
+    }
+
+    companion object {
+        const val GROUP_KEY_TORRENTS: String = "group_key_torrent"
+        const val KEY_OBSERVED_TORRENTS: String = "observed_torrents_key"
+    }
+}

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -17,6 +17,7 @@ import com.github.livingwithhippos.unchained.data.repositoy.TorrentsRepository
 import com.github.livingwithhippos.unchained.di.SummaryNotification
 import com.github.livingwithhippos.unchained.di.TorrentNotification
 import com.github.livingwithhippos.unchained.utilities.extension.getStatusTranslation
+import com.github.livingwithhippos.unchained.utilities.extension.vibrate
 import com.github.livingwithhippos.unchained.utilities.loadingStatusList
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -122,6 +123,8 @@ class ForegroundTorrentService : LifecycleService() {
             finishedTorrents.forEach { torrent ->
                 completeNotification(torrent)
             }
+            if (finishedTorrents.isNotEmpty())
+                applicationContext.vibrate()
 
         })
 

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -13,6 +13,7 @@ import com.github.livingwithhippos.unchained.R
 import com.github.livingwithhippos.unchained.data.model.TorrentItem
 import com.github.livingwithhippos.unchained.data.repositoy.CredentialsRepository
 import com.github.livingwithhippos.unchained.data.repositoy.TorrentsRepository
+import com.github.livingwithhippos.unchained.utilities.loadingStatusList
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -40,16 +41,6 @@ class ForegroundTorrentService : LifecycleService() {
     @Inject
     lateinit var preferences: SharedPreferences
 
-    // possible status are magnet_error, magnet_conversion, waiting_files_selection,
-    // queued, downloading, downloaded, error, virus, compressing, uploading, dead
-    private val loadingStatusList = listOf(
-        "downloading",
-        "magnet_conversion",
-        "waiting_files_selection",
-        "queued",
-        "compressing",
-        "uploading"
-    )
 
     override fun onBind(intent: Intent): IBinder? {
         super.onBind(intent)

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/service/ForegroundTorrentService.kt
@@ -1,21 +1,27 @@
 package com.github.livingwithhippos.unchained.data.service
 
 import android.app.Notification
+import android.app.PendingIntent
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Binder
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.TaskStackBuilder
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.lifecycleScope
+import androidx.preference.SwitchPreference
 import com.github.livingwithhippos.unchained.R
+import com.github.livingwithhippos.unchained.base.MainActivity
 import com.github.livingwithhippos.unchained.data.model.TorrentItem
 import com.github.livingwithhippos.unchained.data.repositoy.CredentialsRepository
 import com.github.livingwithhippos.unchained.data.repositoy.TorrentsRepository
 import com.github.livingwithhippos.unchained.di.SummaryNotification
 import com.github.livingwithhippos.unchained.di.TorrentNotification
+import com.github.livingwithhippos.unchained.settings.SettingsFragment
 import com.github.livingwithhippos.unchained.utilities.extension.getStatusTranslation
 import com.github.livingwithhippos.unchained.utilities.extension.vibrate
 import com.github.livingwithhippos.unchained.utilities.loadingStatusList
@@ -62,7 +68,7 @@ class ForegroundTorrentService : LifecycleService() {
     /**
      * Binder for the client. It can be used to retrieve this service and call its public methods.
      */
-    inner class TorrentServiceBinder : Binder() {
+    inner class TorrentBinder : Binder() {
         internal val service: ForegroundTorrentService
             get() = this@ForegroundTorrentService
     }
@@ -129,6 +135,15 @@ class ForegroundTorrentService : LifecycleService() {
         })
 
         startForeground(SUMMARY_ID, summaryBuilder.build())
+
+
+        preferences.registerOnSharedPreferenceChangeListener { sharedPreferences, key ->
+            if (key==SettingsFragment.KEY_TORRENT_NOTIFICATIONS) {
+                val enableTorrentNotifications = sharedPreferences.getBoolean(key, false)
+                if (!enableTorrentNotifications)
+                    stopTorrentService()
+            }
+        }
 
     }
 
@@ -201,11 +216,17 @@ class ForegroundTorrentService : LifecycleService() {
         }
     }
 
+    fun stopTorrentService() {
+        stopSelf()
+    }
+
     companion object {
         const val GROUP_KEY_TORRENTS: String = "group_key_torrent"
         const val KEY_OBSERVED_TORRENTS: String = "observed_torrents_key"
         const val UPDATE_TIMING_SHORT: Long = 5000
         const val UPDATE_TIMING_LONG: Long = 30000
         const val SUMMARY_ID: Int = 21
+        const val  TORRENT_NOTIFICATION_CODE = 86
+        const val  KEY_TORRENT_ID = "torrent_id_key"
     }
 }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/di/NotificationModule.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/di/NotificationModule.kt
@@ -23,7 +23,7 @@ object NotificationModule {
     fun provideTorrentNotificationBuilder(
         @ApplicationContext applicationContext: Context
     ): NotificationCompat.Builder = NotificationCompat.Builder(applicationContext, UnchainedApplication.CHANNEL_ID)
-        .setSmallIcon(R.mipmap.icon_launcher)
+        .setSmallIcon(R.drawable.logo_no_background)
         .setPriority(NotificationCompat.PRIORITY_LOW)
         .setGroup(ForegroundTorrentService.GROUP_KEY_TORRENTS)
 
@@ -33,7 +33,7 @@ object NotificationModule {
     fun provideSummaryNotificationBuilder(
         @ApplicationContext applicationContext: Context
     ): NotificationCompat.Builder = NotificationCompat.Builder(applicationContext, UnchainedApplication.CHANNEL_ID)
-        .setSmallIcon(R.mipmap.icon_launcher)
+        .setSmallIcon(R.drawable.logo_no_background)
         .setContentTitle(applicationContext.getString(R.string.monitor_torrents_download))
         .setPriority(NotificationCompat.PRIORITY_LOW)
         .setGroup(ForegroundTorrentService.GROUP_KEY_TORRENTS)

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/di/NotificationModule.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/di/NotificationModule.kt
@@ -19,12 +19,25 @@ object NotificationModule {
 
     @ServiceScoped
     @Provides
-    fun provideNotificationBuilder(
+    @TorrentNotification
+    fun provideTorrentNotificationBuilder(
         @ApplicationContext applicationContext: Context
     ): NotificationCompat.Builder = NotificationCompat.Builder(applicationContext, UnchainedApplication.CHANNEL_ID)
         .setSmallIcon(R.mipmap.icon_launcher)
         .setPriority(NotificationCompat.PRIORITY_LOW)
         .setGroup(ForegroundTorrentService.GROUP_KEY_TORRENTS)
+
+    @ServiceScoped
+    @Provides
+    @SummaryNotification
+    fun provideSummaryNotificationBuilder(
+        @ApplicationContext applicationContext: Context
+    ): NotificationCompat.Builder = NotificationCompat.Builder(applicationContext, UnchainedApplication.CHANNEL_ID)
+        .setSmallIcon(R.mipmap.icon_launcher)
+        .setContentTitle(applicationContext.getString(R.string.app_name))
+        .setPriority(NotificationCompat.PRIORITY_LOW)
+        .setGroup(ForegroundTorrentService.GROUP_KEY_TORRENTS)
+        .setGroupSummary(true)
 
     @ServiceScoped
     @Provides

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/di/NotificationModule.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/di/NotificationModule.kt
@@ -34,7 +34,7 @@ object NotificationModule {
         @ApplicationContext applicationContext: Context
     ): NotificationCompat.Builder = NotificationCompat.Builder(applicationContext, UnchainedApplication.CHANNEL_ID)
         .setSmallIcon(R.mipmap.icon_launcher)
-        .setContentTitle(applicationContext.getString(R.string.app_name))
+        .setContentTitle(applicationContext.getString(R.string.monitor_torrents_download))
         .setPriority(NotificationCompat.PRIORITY_LOW)
         .setGroup(ForegroundTorrentService.GROUP_KEY_TORRENTS)
         .setGroupSummary(true)

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/di/NotificationModule.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/di/NotificationModule.kt
@@ -1,0 +1,34 @@
+package com.github.livingwithhippos.unchained.di
+
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.github.livingwithhippos.unchained.R
+import com.github.livingwithhippos.unchained.base.UnchainedApplication
+import com.github.livingwithhippos.unchained.data.service.ForegroundTorrentService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ServiceComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ServiceScoped
+
+@Module
+@InstallIn(ServiceComponent::class)
+object NotificationModule {
+
+    @ServiceScoped
+    @Provides
+    fun provideNotificationBuilder(
+        @ApplicationContext applicationContext: Context
+    ): NotificationCompat.Builder = NotificationCompat.Builder(applicationContext, UnchainedApplication.CHANNEL_ID)
+        .setSmallIcon(R.mipmap.icon_launcher)
+        .setPriority(NotificationCompat.PRIORITY_LOW)
+        .setGroup(ForegroundTorrentService.GROUP_KEY_TORRENTS)
+
+    @ServiceScoped
+    @Provides
+    fun provideNotificationManager(
+        @ApplicationContext applicationContext: Context
+    ): NotificationManagerCompat = NotificationManagerCompat.from(applicationContext)
+}

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/di/qualifiers.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/di/qualifiers.kt
@@ -10,3 +10,11 @@ annotation class AuthRetrofit
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class ApiRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class TorrentNotification
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class SummaryNotification

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/lists/view/ListsTabFragment.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/lists/view/ListsTabFragment.kt
@@ -20,6 +20,7 @@ import com.github.livingwithhippos.unchained.lists.viewmodel.DownloadListViewMod
 import com.github.livingwithhippos.unchained.utilities.endedStatusList
 import com.github.livingwithhippos.unchained.utilities.extension.showToast
 import com.github.livingwithhippos.unchained.utilities.extension.verticalScrollToPosition
+import com.github.livingwithhippos.unchained.utilities.loadingStatusList
 import com.google.android.material.tabs.TabLayout
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/newdownload/view/NewDownloadFragment.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/newdownload/view/NewDownloadFragment.kt
@@ -54,6 +54,8 @@ import java.util.regex.Pattern
 @AndroidEntryPoint
 class NewDownloadFragment : UnchainedFragment(), NewDownloadListener {
 
+    // todo: switch to the navigation scoped viewmodel to manage the transition between fragments
+    // if we receive an intent and new download is already selected and showing a DownloadDetailsFragment, it may not trigger the observers in this class
     private val viewModel: NewDownloadViewModel by viewModels()
 
     private val args: NewDownloadFragmentArgs by navArgs()
@@ -242,6 +244,16 @@ class NewDownloadFragment : UnchainedFragment(), NewDownloadListener {
                 // already handled
                 null -> {
                 }
+            }
+        })
+
+        activityViewModel.notificationTorrentLiveData.observe(viewLifecycleOwner, {
+            it.getContentIfNotHandled()?.let { torrentID ->
+                val action =
+                    NewDownloadFragmentDirections.actionNewDownloadDestToTorrentDetailsFragment(
+                        torrentID
+                    )
+                findNavController().navigate(action)
             }
         })
 

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/settings/SettingsFragment.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/settings/SettingsFragment.kt
@@ -1,12 +1,17 @@
 package com.github.livingwithhippos.unchained.settings
 
+import android.content.ComponentName
+import android.content.ServiceConnection
 import android.content.SharedPreferences
 import android.os.Bundle
+import android.os.IBinder
 import androidx.fragment.app.viewModels
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreference
 import com.github.livingwithhippos.unchained.R
+import com.github.livingwithhippos.unchained.data.service.ForegroundTorrentService
 import com.github.livingwithhippos.unchained.utilities.FEEDBACK_URL
 import com.github.livingwithhippos.unchained.utilities.GPLV3_URL
 import com.github.livingwithhippos.unchained.utilities.extension.openExternalWebPage
@@ -101,6 +106,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         // these must match the ones used in [xml/settings.xml]
         const val KEY_DAY_NIGHT = "day_night_theme"
         const val KEY_THEME = "current_theme"
+        const val KEY_TORRENT_NOTIFICATIONS = "notification_torrent_key"
         const val THEME_AUTO = "auto"
         const val THEME_NIGHT = "night"
         const val THEME_DAY = "day"

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/start/viewmodel/MainActivityViewModel.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/start/viewmodel/MainActivityViewModel.kt
@@ -15,6 +15,7 @@ import com.github.livingwithhippos.unchained.data.model.User
 import com.github.livingwithhippos.unchained.data.repositoy.AuthenticationRepository
 import com.github.livingwithhippos.unchained.data.repositoy.CredentialsRepository
 import com.github.livingwithhippos.unchained.data.repositoy.HostsRepository
+import com.github.livingwithhippos.unchained.data.repositoy.TorrentsRepository
 import com.github.livingwithhippos.unchained.data.repositoy.UserRepository
 import com.github.livingwithhippos.unchained.data.repositoy.VariousApiRepository
 import com.github.livingwithhippos.unchained.lists.view.ListsTabFragment
@@ -45,6 +46,8 @@ class MainActivityViewModel @ViewModelInject constructor(
     val externalLinkLiveData = MutableLiveData<Event<Uri?>>()
 
     val downloadedTorrentLiveData = MutableLiveData<Event<String?>>()
+
+    val notificationTorrentLiveData = MutableLiveData<Event<String>>()
 
     val listStateLiveData = MutableLiveData<Event<ListsTabFragment.ListState>>()
 
@@ -224,6 +227,10 @@ class MainActivityViewModel @ViewModelInject constructor(
                 }
             }
         }
+    }
+
+    fun addTorrentId(torrentID: String) {
+        notificationTorrentLiveData.postValue(Event(torrentID))
     }
 
     companion object {

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/view/TorrentDetailsFragment.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/view/TorrentDetailsFragment.kt
@@ -21,6 +21,7 @@ import com.github.livingwithhippos.unchained.lists.view.ListsTabFragment
 import com.github.livingwithhippos.unchained.torrentdetails.viewmodel.TorrentDetailsViewModel
 import com.github.livingwithhippos.unchained.utilities.extension.observeOnce
 import com.github.livingwithhippos.unchained.utilities.extension.showToast
+import com.github.livingwithhippos.unchained.utilities.loadingStatusList
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -35,16 +36,6 @@ class TorrentDetailsFragment : UnchainedFragment(), TorrentDetailsListener {
     private val viewModel: TorrentDetailsViewModel by viewModels()
 
     private val args: TorrentDetailsFragmentArgs by navArgs()
-
-    // possible status are magnet_error, magnet_conversion, waiting_files_selection,
-    // queued, downloading, downloaded, error, virus, compressing, uploading, dead
-    val loadingStatusList = listOf(
-        "magnet_conversion",
-        "waiting_files_selection",
-        "queued",
-        "compressing",
-        "uploading"
-    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/view/TorrentDetailsFragment.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/view/TorrentDetailsFragment.kt
@@ -88,14 +88,12 @@ class TorrentDetailsFragment : UnchainedFragment(), TorrentDetailsListener {
         }, true)
 
         viewModel.torrentLiveData.observe(viewLifecycleOwner, {
-            if (it != null) {
-                torrentBinding.torrent = it
-                if (loadingStatusList.contains(it.status) || it.status == "downloading")
+            it.getContentIfNotHandled()?.let {torrent ->
+                torrentBinding.torrent = torrent
+                if (loadingStatusList.contains(torrent.status))
                     fetchTorrent()
             }
         })
-
-        viewModel.fetchTorrentDetails(args.torrentID)
 
         viewModel.deletedTorrentLiveData.observe(viewLifecycleOwner, {
             it.getContentIfNotHandled()?.let {
@@ -120,6 +118,8 @@ class TorrentDetailsFragment : UnchainedFragment(), TorrentDetailsListener {
                 findNavController().navigate(action)
             }
         })
+
+        viewModel.fetchTorrentDetails(args.torrentID)
 
         return torrentBinding.root
     }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/Constants.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/Constants.kt
@@ -66,3 +66,14 @@ val errorMap = mapOf(
 
 val endedStatusList = listOf("magnet_error", "downloaded", "error", "virus", "dead")
 
+// possible status are magnet_error, magnet_conversion, waiting_files_selection,
+// queued, downloading, downloaded, error, virus, compressing, uploading, dead
+val loadingStatusList = listOf(
+    "downloading",
+    "magnet_conversion",
+    "waiting_files_selection",
+    "queued",
+    "compressing",
+    "uploading"
+)
+

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/extension/Extension.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/extension/Extension.kt
@@ -8,6 +8,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
 import android.net.Uri
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
 import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -227,5 +230,14 @@ fun Context.getStatusTranslation(status: String): String {
         "uploading" -> getString(R.string.uploading)
         "dead" -> getString(R.string.dead)
         else -> getString(R.string.unknown_status)
+    }
+}
+
+fun Context.vibrate(duration: Long = 200){
+    val vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        vibrator.vibrate(VibrationEffect.createOneShot(duration, VibrationEffect.DEFAULT_AMPLITUDE))
+    } else {
+        vibrator.vibrate(duration)
     }
 }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/extension/Extension.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/extension/Extension.kt
@@ -18,7 +18,6 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.Observer
 import com.github.livingwithhippos.unchained.BuildConfig
 import com.github.livingwithhippos.unchained.R
-import com.github.livingwithhippos.unchained.settings.SettingsFragment
 import java.util.*
 
 /**
@@ -210,5 +209,23 @@ fun Context.getApiErrorMessage(errorCode: Int): String {
         32 -> getString(R.string.image_resolution_error)
         33 -> getString(R.string.torrent_already_active)
         else -> getString(R.string.unknown_error)
+    }
+}
+
+
+fun Context.getStatusTranslation(status: String): String {
+    return when(status) {
+        "magnet_error" -> getString(R.string.magnet_error)
+        "magnet_conversion" -> getString(R.string.magnet_conversion)
+        "waiting_files_selection" -> getString(R.string.waiting_files_selection)
+        "queued" -> getString(R.string.queued)
+        "downloading" -> getString(R.string.downloading)
+        "downloaded" -> getString(R.string.downloaded)
+        "error" -> getString(R.string.error)
+        "virus" -> getString(R.string.virus)
+        "compressing" -> getString(R.string.compressing)
+        "uploading" -> getString(R.string.uploading)
+        "dead" -> getString(R.string.dead)
+        else -> getString(R.string.unknown_status)
     }
 }

--- a/app/app/src/main/res/drawable/logo_no_background.xml
+++ b/app/app/src/main/res/drawable/logo_no_background.xml
@@ -1,0 +1,36 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="15.08125dp"
+    android:height="15.08125dp"
+    android:viewportWidth="15.08125"
+    android:viewportHeight="15.081251">
+  <path
+      android:pathData="M6.7884,6.835 L4.5488,8.5646"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="0.792503"
+      android:fillColor="#00000000"
+      android:strokeColor="#ff6b58"
+      android:strokeLineCap="butt"/>
+  <path
+      android:pathData="m4.1167,7.9239c-0.5476,0 -0.9941,0.4495 -0.9941,0.9979 0,0.5496 0.4464,0.9998 0.9941,0.9998 0.5477,0 0.996,-0.4499 0.996,-0.9998 0,-0.5487 -0.4483,-0.9979 -0.996,-0.9979zM4.1167,8.5646c0.1976,0 0.3572,0.1587 0.3572,0.3572 0,0.1985 -0.1601,0.3591 -0.3572,0.3591 -0.1969,0 -0.3553,-0.1601 -0.3553,-0.3591 0,-0.199 0.1578,-0.3572 0.3553,-0.3572z"
+      android:strokeWidth="2.34631"
+      android:fillColor="#f8b660"
+      android:strokeColor="#00000000"
+      android:fillType="nonZero"/>
+  <path
+      android:pathData="M8.5075,8.9199A3.3593,3.3593 0,0 1,5.4069 12.2692,3.3593 3.3593,0 0,1 1.8287,9.4358 3.3593,3.3593 0,0 1,4.3782 5.65"
+      android:strokeWidth="1.27149"
+      android:fillColor="#00000000"
+      android:strokeColor="#d20076"/>
+  <path
+      android:pathData="m6.5737,6.1613a3.3593,3.3593 0,0 1,3.1006 -3.3493,3.3593 3.3593,0 0,1 3.5782,2.8335 3.3593,3.3593 0,0 1,-2.5495 3.7858"
+      android:strokeWidth="1.27149"
+      android:fillColor="#00000000"
+      android:strokeColor="#ff4373"/>
+  <path
+      android:pathData="M4.7212,3.6897 L10.8871,12.1079"
+      android:strokeLineJoin="miter"
+      android:strokeWidth="1.27149"
+      android:fillColor="#00000000"
+      android:strokeColor="#f8b660"
+      android:strokeLineCap="butt"/>
+</vector>

--- a/app/app/src/main/res/layout-land/fragment_download_details.xml
+++ b/app/app/src/main/res/layout-land/fragment_download_details.xml
@@ -141,7 +141,7 @@
 
             <Button
                 android:id="@+id/bOpen"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
+                style="@style/Widget.MaterialComponents.Button.Icon"
                 android:layout_width="0dp"
                 android:layout_height="80dp"
                 android:layout_marginTop="20dp"
@@ -155,7 +155,7 @@
 
             <Button
                 android:id="@+id/bCopy"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
+                style="@style/Widget.MaterialComponents.Button.Icon"
                 android:layout_width="0dp"
                 android:layout_height="80dp"
                 android:layout_marginTop="20dp"
@@ -169,7 +169,7 @@
 
             <Button
                 android:id="@+id/bOpenWith"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
+                style="@style/Widget.MaterialComponents.Button.Icon"
                 android:layout_width="0dp"
                 android:layout_height="80dp"
                 android:layout_marginTop="20dp"
@@ -184,7 +184,7 @@
 
             <Button
                 android:id="@+id/bLoadStreams"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
+                style="@style/Widget.MaterialComponents.Button.Icon"
                 android:layout_width="0dp"
                 android:layout_height="80dp"
                 android:layout_marginTop="20dp"

--- a/app/app/src/main/res/layout/fragment_download_details.xml
+++ b/app/app/src/main/res/layout/fragment_download_details.xml
@@ -151,7 +151,7 @@
 
             <Button
                 android:id="@+id/bOpen"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
+                style="@style/Widget.MaterialComponents.Button.Icon"
                 android:layout_width="0dp"
                 android:layout_height="80dp"
                 android:layout_marginTop="20dp"
@@ -165,7 +165,7 @@
 
             <Button
                 android:id="@+id/bCopy"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
+                style="@style/Widget.MaterialComponents.Button.Icon"
                 android:layout_width="0dp"
                 android:layout_height="80dp"
                 android:layout_marginTop="20dp"
@@ -179,7 +179,7 @@
 
             <Button
                 android:id="@+id/bOpenWith"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
+                style="@style/Widget.MaterialComponents.Button.Icon"
                 android:layout_width="0dp"
                 android:layout_height="80dp"
                 android:layout_marginTop="5dp"
@@ -194,7 +194,7 @@
 
             <Button
                 android:id="@+id/bLoadStreams"
-                style="@style/Widget.MaterialComponents.Button.OutlinedButton.Icon"
+                style="@style/Widget.MaterialComponents.Button.Icon"
                 android:layout_width="0dp"
                 android:layout_height="80dp"
                 android:layout_marginTop="5dp"

--- a/app/app/src/main/res/layout/fragment_torrent_details.xml
+++ b/app/app/src/main/res/layout/fragment_torrent_details.xml
@@ -107,7 +107,7 @@
                 <com.google.android.material.progressindicator.ProgressIndicator
                     android:id="@+id/loadingCircle"
                     style="@style/Widget.MaterialComponents.ProgressIndicator.Circular.Indeterminate"
-                    android:visibility="@{loadingStatusList.contains(torrent.status) ? View.VISIBLE : View.GONE}"
+                    android:visibility="@{loadingStatusList.contains(torrent.status) &amp;&amp; torrent.status!=`downloading` ? View.VISIBLE : View.GONE}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="10dp"
@@ -213,7 +213,6 @@
                         android:minHeight="60dp"
                         android:progress="@{torrent.progress}"
                         android:progressDrawable="@drawable/download_progressbar"
-                        android:visibility="@{loadingStatusList.contains(torrent.status) ? View.GONE : View.VISIBLE}"
                         app:progressColor="@{@color/streaming_background}" />
 
                 </FrameLayout>

--- a/app/app/src/main/res/layout/fragment_torrent_details.xml
+++ b/app/app/src/main/res/layout/fragment_torrent_details.xml
@@ -107,7 +107,7 @@
                 <com.google.android.material.progressindicator.ProgressIndicator
                     android:id="@+id/loadingCircle"
                     style="@style/Widget.MaterialComponents.ProgressIndicator.Circular.Indeterminate"
-                    android:visibility="@{loadingStatusList.contains(torrent.status) &amp;&amp; torrent.status!=`downloading` ? View.VISIBLE : View.GONE}"
+                    android:visibility="@{loadingStatusList.contains(torrent.status) &amp;&amp; !torrent.status.equalsIgnoreCase(`downloading`) ? View.VISIBLE : View.GONE}"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="10dp"

--- a/app/app/src/main/res/layout/fragment_torrent_details.xml
+++ b/app/app/src/main/res/layout/fragment_torrent_details.xml
@@ -224,13 +224,18 @@
 
         <Button
             android:id="@+id/bDownload"
+            style="@style/Widget.MaterialComponents.Button.Icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:onClick="@{() -> listener.onDownloadClick(torrent.links)}"
             android:layout_marginBottom="20dp"
             android:text="@string/download"
-            android:onClick="@{() -> listener.onDownloadClick(torrent.links)}"
             android:visibility="@{torrent.status.equalsIgnoreCase(`downloaded`) ? View.VISIBLE : View.GONE}"
-            android:layout_gravity="center_horizontal" />
+            android:layout_gravity="center_horizontal"
+            app:icon="@drawable/icon_download"
+            app:layout_constraintStart_toStartOf="@id/cvDetails"
+            app:layout_constraintEnd_toStartOf="@id/bCopy"
+            app:layout_constraintTop_toBottomOf="@id/cvDetails" />
 
 
     </LinearLayout>

--- a/app/app/src/main/res/values-it/strings.xml
+++ b/app/app/src/main/res/values-it/strings.xml
@@ -196,5 +196,6 @@
     <string name="torrent_in_progress_format">%1$d%% - Download in corso</string>
     <string name="download_complete">Download completato</string>
     <string name="status_unknown">Stato sconosciuto</string>
-    <string name="downloading_torrent_format">Scaricando %1$d torrents</string>
+    <string name="downloading_torrent_format">%1$d torrents in download</string>
+    <string name="monitor_torrents_download">Controllando torrents</string>
 </resources>

--- a/app/app/src/main/res/values-it/strings.xml
+++ b/app/app/src/main/res/values-it/strings.xml
@@ -196,4 +196,5 @@
     <string name="torrent_in_progress_format">%1$d%% - Download in corso</string>
     <string name="download_complete">Download completato</string>
     <string name="status_unknown">Stato sconosciuto</string>
+    <string name="downloading_torrent_format">Scaricando %1$d torrents</string>
 </resources>

--- a/app/app/src/main/res/values-it/strings.xml
+++ b/app/app/src/main/res/values-it/strings.xml
@@ -198,4 +198,6 @@
     <string name="unknown_status">Stato sconosciuto</string>
     <string name="downloading_torrent_format">%1$d torrent in download</string>
     <string name="monitor_torrents_download">Controllando torrent</string>
+    <string name="notifications">Notifiche</string>
+    <string name="enable_torrent_monitoring_title">Abilita controllo torrent</string>
 </resources>

--- a/app/app/src/main/res/values-it/strings.xml
+++ b/app/app/src/main/res/values-it/strings.xml
@@ -193,9 +193,9 @@
     <string name="network_error">Errore di rete</string>
     <string name="torrent_channel_description">Canale di notifiche per il download dei torrent</string>
     <string name="torrent_in_progress">Download torrent in corso</string>
-    <string name="torrent_in_progress_format">%1$d%% - Download in corso</string>
+    <string name="torrent_in_progress_format">%1$d%% - %2$.2f MB/s</string>
     <string name="download_complete">Download completato</string>
     <string name="status_unknown">Stato sconosciuto</string>
-    <string name="downloading_torrent_format">%1$d torrents in download</string>
-    <string name="monitor_torrents_download">Controllando torrents</string>
+    <string name="downloading_torrent_format">%1$d torrent in download</string>
+    <string name="monitor_torrents_download">Controllando torrent</string>
 </resources>

--- a/app/app/src/main/res/values-it/strings.xml
+++ b/app/app/src/main/res/values-it/strings.xml
@@ -191,4 +191,9 @@
     <string name="updating_link_matcher">Aggiornamento dei link…</string>
     <string name="unknown_error">Errore sconosciuto</string>
     <string name="network_error">Errore di rete</string>
+    <string name="torrent_channel_description">Canale di notifiche per il download dei torrent</string>
+    <string name="torrent_in_progress">Download torrent in corso</string>
+    <string name="torrent_in_progress_format">%1$d%% - Download in corso</string>
+    <string name="download_complete">Download completato</string>
+    <string name="status_unknown">Stato sconosciuto</string>
 </resources>

--- a/app/app/src/main/res/values-it/strings.xml
+++ b/app/app/src/main/res/values-it/strings.xml
@@ -195,7 +195,7 @@
     <string name="torrent_in_progress">Download torrent in corso</string>
     <string name="torrent_in_progress_format">%1$d%% - %2$.2f MB/s</string>
     <string name="download_complete">Download completato</string>
-    <string name="status_unknown">Stato sconosciuto</string>
+    <string name="unknown_status">Stato sconosciuto</string>
     <string name="downloading_torrent_format">%1$d torrent in download</string>
     <string name="monitor_torrents_download">Controllando torrent</string>
 </resources>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -412,4 +412,5 @@
     <string name="torrent_in_progress_format">%1$d%% - Download in progress</string>
     <string name="download_complete">Download complete</string>
     <string name="status_unknown">Unknown Status</string>
+    <string name="downloading_torrent_format">Downloading %1$d torrents</string>
 </resources>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -411,7 +411,7 @@
     <string name="torrent_in_progress">Torrent download in progress</string>
     <string name="torrent_in_progress_format">%1$d%% - %2$.2f MB/s</string>
     <string name="download_complete">Download complete</string>
-    <string name="status_unknown">Unknown Status</string>
+    <string name="unknown_status">Unknown Status</string>
     <string name="downloading_torrent_format">Downloading %1$d torrents</string>
     <string name="monitor_torrents_download">Monitoring torrents download</string>
 </resources>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -409,7 +409,7 @@
     <string name="network_error">Network error</string>
     <string name="torrent_channel_description">Notification channel for torrents download status</string>
     <string name="torrent_in_progress">Torrent download in progress</string>
-    <string name="torrent_in_progress_format">%1$d%% - Download in progress</string>
+    <string name="torrent_in_progress_format">%1$d%% - %2$.2f MB/s</string>
     <string name="download_complete">Download complete</string>
     <string name="status_unknown">Unknown Status</string>
     <string name="downloading_torrent_format">Downloading %1$d torrents</string>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -413,4 +413,5 @@
     <string name="download_complete">Download complete</string>
     <string name="status_unknown">Unknown Status</string>
     <string name="downloading_torrent_format">Downloading %1$d torrents</string>
+    <string name="monitor_torrents_download">Monitoring torrents download</string>
 </resources>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -414,4 +414,6 @@
     <string name="unknown_status">Unknown Status</string>
     <string name="downloading_torrent_format">Downloading %1$d torrents</string>
     <string name="monitor_torrents_download">Monitoring torrents download</string>
+    <string name="notifications">Notifications</string>
+    <string name="enable_torrent_monitoring_title">Enable torrent monitoring</string>
 </resources>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -407,4 +407,9 @@
     <string name="updating_link_matcher">Updating link matcher…</string>
     <string name="unknown_error">Unknown error</string>
     <string name="network_error">Network error</string>
+    <string name="torrent_channel_description">Notification channel for torrents download status</string>
+    <string name="torrent_in_progress">Torrent download in progress</string>
+    <string name="torrent_in_progress_format">%1$d%% - Download in progress</string>
+    <string name="download_complete">Download complete</string>
+    <string name="status_unknown">Unknown Status</string>
 </resources>

--- a/app/app/src/main/res/xml/settings.xml
+++ b/app/app/src/main/res/xml/settings.xml
@@ -38,7 +38,7 @@
         android:title="@string/notifications">
 
         <SwitchPreference
-            app:key="enable_torrent_notifications"
+            app:key="notification_torrent_key"
             app:title="@string/enable_torrent_monitoring_title"
             android:defaultValue="false"/>
 

--- a/app/app/src/main/res/xml/settings.xml
+++ b/app/app/src/main/res/xml/settings.xml
@@ -35,6 +35,16 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:title="@string/notifications">
+
+        <SwitchPreference
+            app:key="enable_torrent_notifications"
+            app:title="@string/enable_torrent_monitoring_title"
+            android:defaultValue="false"/>
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:title="@string/title_various">
 
     <Preference


### PR DESCRIPTION
Shows a permanent notification, to be enabled in the settings, for torrents in an active state. The notification indicates the state, speed, and progress of the torrent.  It's possible to click on a torrent to get to its TorrentDetailsFragment.

Çloses #57 