### PR TITLE
Fix the errors in the CI system when `gradlew lint test` is run

### DIFF
--- a/app/app/src/test/java/com/github/livingwithhippos/unchained/TestJunit5.kt
+++ b/app/app/src/test/java/com/github/livingwithhippos/unchained/TestJunit5.kt
@@ -1,0 +1,9 @@
+package com.github.livingwithhippos.unchained
+
+
+/**
+ * This file is used to avoid errors with `gradlew lint test`
+ *
+ */
+class BypassLintErrorTest {
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,6 +35,5 @@ allprojects {
 subprojects {
     apply plugin: "org.jlleitschuh.gradle.ktlint"
     ktlint {
-        debug = true
     }
 }


### PR DESCRIPTION
Exception:

```java
 Execution failed for task ':app:transformDebugUnitTestClassesWithAsm'.
> java.nio.file.NoSuchFileException: /home/runner/work/unchained-android/unchained-android/app/app/build/tmp/kotlin-classes/debugUnitTest
```

adding a fake Unit Test under the `src/test` folder seems to have worked. See [BypassLintErrorTest](../tree/master/app/app/src/test/TestUnit5.kt)