### PR TITLE
Parse direct for search

### DIFF
--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/plugins/Parser.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/plugins/Parser.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import android.text.Spanned
 import androidx.core.text.HtmlCompat
 import com.github.livingwithhippos.unchained.plugins.model.CustomRegex
+import com.github.livingwithhippos.unchained.plugins.model.DirectParser
 import com.github.livingwithhippos.unchained.plugins.model.Plugin
 import com.github.livingwithhippos.unchained.plugins.model.PluginRegexes
 import com.github.livingwithhippos.unchained.plugins.model.RegexpsGroup
@@ -21,7 +22,6 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import timber.log.Timber
-import java.net.SocketTimeoutException
 
 class Parser(
     private val preferences: SharedPreferences,
@@ -111,6 +111,19 @@ class Parser(
                                 } else {
                                     emit(ParserResult.EmptyInnerLinks)
                                 }
+                            }
+                            plugin.download.directParser != null -> {
+                                emit(
+                                    ParserResult.Results(
+                                        parseDirect(
+                                            plugin.download.directParser,
+                                            plugin.download.regexes,
+                                            source,
+                                            plugin.url
+                                        )
+                                    )
+                                )
+                                emit(ParserResult.SearchFinished)
                             }
                             plugin.download.tableLink != null -> {
                                 emit(
@@ -394,9 +407,9 @@ class Parser(
                 var seeders: String? = null
                 var leechers: String? = null
                 var size: String? = null
-                var magnets = mutableSetOf<String>()
-                var torrents = mutableSetOf<String>()
-                var hosting = mutableSetOf<String>()
+                val magnets = mutableSetOf<String>()
+                val torrents = mutableSetOf<String>()
+                val hosting = mutableSetOf<String>()
                 try {
 
                     if (tableLink.columns.nameColumn != null)
@@ -689,6 +702,59 @@ class Parser(
         else emptyList()
     }
 
+    private fun parseDirect(
+        directParser: DirectParser?,
+        regexes: PluginRegexes,
+        source: String,
+        url: String
+    ): List<ScrapedItem> {
+        // todo: implement class and id filtering
+        // todo: implement more robust method to parse multiple links for a single source
+        // maybe let the class filtering separate all of the pieces like a row
+        val directItems = mutableListOf<ScrapedItem>()
+
+        val nameRegex = regexes.nameRegex.regexps
+        val names = parseList(nameRegex, source, url)
+        val magnetRegex = regexes.magnetRegex?.regexps
+        val magnets = parseList(magnetRegex, source, url)
+        val torrentsRegex = regexes.torrentRegexes?.regexps
+        val torrents = parseList(torrentsRegex, source, url)
+        val hostingRegex = regexes.hostingRegexes?.regexps
+        val hosting = parseList(hostingRegex, source, url)
+
+        if (names.isNotEmpty() && (magnets.isNotEmpty() || torrents.isNotEmpty() || hosting.isNotEmpty())) {
+
+            val seedersRegex = regexes.seedersRegex?.regexps
+            val seeders = parseList(seedersRegex, source, url)
+            val leechersRegex = regexes.leechersRegex?.regexps
+            val leechers = parseList(leechersRegex, source, url)
+            val sizeRegex = regexes.sizeRegex?.regexps
+            val size = parseList(sizeRegex, source, url)
+            val detailsRegex = regexes.detailsRegex?.regexps
+            val details = parseList(detailsRegex, source, url)
+
+            // checking the max size of combinations between names, torrents, hosting and magnets I can find
+            val maxSize: Int = minOf( names.size, maxOf(magnets.size, torrents.size, hosting.size))
+            for (index in 0..maxSize) {
+                directItems.add(
+                    ScrapedItem(
+                        names[index],
+                        details.getOrNull(index),
+                        seeders.getOrNull(index),
+                        leechers.getOrNull(index),
+                        size.getOrNull(index),
+                        parseCommonSize(size.getOrNull(index)),
+                        if (magnets.getOrNull(index) != null) listOf(magnets[index]) else emptyList(),
+                        if (torrents.getOrNull(index) != null) listOf(torrents[index]) else emptyList(),
+                        if (hosting.getOrNull(index) != null) listOf(hosting[index]) else emptyList()
+                    )
+                )
+            }
+            return directItems
+
+        } else return emptyList()
+    }
+
     private fun getCategory(plugin: Plugin, category: String): String? {
         return when (category) {
             "all" -> plugin.supportedCategories.all
@@ -719,8 +785,9 @@ class Parser(
          * 1.1: added skipping of empty rows in tables
          * 1.2: added table_indirect
          * 2.0: use array for all regexps
+         * 2.1: added direct parsing mode
          */
-        const val PLUGIN_ENGINE_VERSION: Float = 2.0f
+        const val PLUGIN_ENGINE_VERSION: Float = 2.1f
     }
 }
 

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/plugins/model/Plugin.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/plugins/model/Plugin.kt
@@ -8,9 +8,9 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class Plugin(
     @Json(name = "engine_version")
-    val engineVersion: Double,
+    val engineVersion: Float,
     @Json(name = "version")
-    val version: Double,
+    val version: Float,
     @Json(name = "url")
     val url: String,
     @Json(name = "name")
@@ -27,8 +27,8 @@ data class Plugin(
     val download: PluginDownload
 ) : Parcelable {
     constructor(parcel: Parcel) : this(
-        parcel.readDouble(),
-        parcel.readDouble(),
+        parcel.readFloat(),
+        parcel.readFloat(),
         parcel.readString()!!,
         parcel.readString()!!,
         parcel.readString(),
@@ -39,8 +39,8 @@ data class Plugin(
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeDouble(engineVersion)
-        parcel.writeDouble(version)
+        parcel.writeFloat(engineVersion)
+        parcel.writeFloat(version)
         parcel.writeString(url)
         parcel.writeString(name)
         parcel.writeString(description)
@@ -161,6 +161,8 @@ data class PluginSearch(
 data class PluginDownload(
     @Json(name = "internal")
     val internalParser: InternalParser?,
+    @Json(name = "direct")
+    val directParser: DirectParser?,
     @Json(name = "table_direct")
     val tableLink: TableParser?,
     @Json(name = "table_indirect")
@@ -172,11 +174,13 @@ data class PluginDownload(
         parcel.readParcelable(InternalParser::class.java.classLoader),
         parcel.readParcelable(TableParser::class.java.classLoader),
         parcel.readParcelable(TableParser::class.java.classLoader),
+        parcel.readParcelable(TableParser::class.java.classLoader),
         parcel.readParcelable(PluginRegexes::class.java.classLoader)!!
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeParcelable(internalParser, flags)
+        parcel.writeParcelable(directParser, flags)
         parcel.writeParcelable(tableLink, flags)
         parcel.writeParcelable(indirectTableLink, flags)
         parcel.writeParcelable(regexes, flags)
@@ -344,6 +348,38 @@ data class TableParser(
         parcel.writeString(className)
         parcel.writeString(idName)
         parcel.writeParcelable(columns, flags)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object CREATOR : Parcelable.Creator<TableParser> {
+        override fun createFromParcel(parcel: Parcel): TableParser {
+            return TableParser(parcel)
+        }
+
+        override fun newArray(size: Int): Array<TableParser?> {
+            return arrayOfNulls(size)
+        }
+    }
+}
+
+@JsonClass(generateAdapter = true)
+data class DirectParser(
+    @Json(name = "class")
+    val className: String?,
+    @Json(name = "id")
+    val idName: String?
+) : Parcelable {
+    constructor(parcel: Parcel) : this(
+        parcel.readString(),
+        parcel.readString(),
+    )
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeString(className)
+        parcel.writeString(idName)
     }
 
     override fun describeContents(): Int {

--- a/extra_assets/plugins/template.json5
+++ b/extra_assets/plugins/template.json5
@@ -71,11 +71,22 @@
           {
             "regex": "href=\"(/torrent/[^\"]+)",
             "group": 1,
-            "slug_type": "append_url",
+            "slug_type": "append_other",
             "other": "https://other_url.com"
           }
         ]
       }
+    },
+    // "direct" is one of the parsing methods.
+    // parse directly from the search page when the structure containing them is not a table
+    // usable when torrent/magnet links are directly on the search page
+    // uses the regexes structure to retrieve the various informations
+    "direct": {
+        // both of these are optional, direct can be left empty
+        // restrict the search to a particular class (the first one will be used). Ignored if id is set.
+      "class": "container",
+      // restrict the search to a particular id. if id is set class will be ignored
+      "id": "table-id",
     },
     // "table_direct" is one of the parsing methods.
     // parse directly from an html table in the search page


### PR DESCRIPTION
This adds a new method to parse web pages for link.
It's similar to table direct but does not need a table structure. Informations are paired "as they come" so if I get 10 links and 10 torrents I'll match link 1 and torrent 1, link 2 and torrent 2, etc.
see https://github.com/LivingWithHippos/unchained-android/issues/191#issuecomment-1065916870 for an example