### PR TITLE
Fix top bar overlapping status bar (Android 15)

### DIFF
--- a/app/app/src/main/res/layout/activity_main.xml
+++ b/app/app/src/main/res/layout/activity_main.xml
@@ -7,7 +7,6 @@
         android:id="@+id/home_root"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fitsSystemWindows="true"
         tools:context=".base.MainActivity"
         android:orientation="vertical">
 
@@ -15,6 +14,7 @@
             android:id="@+id/appBarLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:fitsSystemWindows="true"
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.appbar.MaterialToolbar

--- a/app/app/src/main/res/layout/activity_main.xml
+++ b/app/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,7 @@
         android:id="@+id/home_root"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:fitsSystemWindows="true"
         tools:context=".base.MainActivity"
         android:orientation="vertical">
 

--- a/app/app/src/main/res/layout/activity_settings.xml
+++ b/app/app/src/main/res/layout/activity_settings.xml
@@ -5,7 +5,6 @@
     android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:context=".settings.view.SettingsActivity">
 
     <!-- Don't use a custom background in this activity so it's clearer that it's "different" -->
@@ -13,6 +12,7 @@
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent">

--- a/app/app/src/main/res/layout/activity_settings.xml
+++ b/app/app/src/main/res/layout/activity_settings.xml
@@ -5,6 +5,7 @@
     android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".settings.view.SettingsActivity">
 
     <!-- Don't use a custom background in this activity so it's clearer that it's "different" -->

--- a/app/app/src/main/res/values-night/themes.xml
+++ b/app/app/src/main/res/values-night/themes.xml
@@ -2,8 +2,8 @@
     <style name="Theme.Unchained.Material3" parent="Theme.Material3.Dark.NoActionBar">
         <item name="appBarLayoutStyle">@style/Widget.App.AppBarLayout</item>
         <item name="toolbarStyle">@style/Widget.App.Toolbar</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
         <!-- this can be used to customize backgrounds with images, otherwise it will use the default android:colorBackground value -->
         <item name="mainBackground">@drawable/bg_solid</item>
     </style>

--- a/app/app/src/main/res/values-night/themes.xml
+++ b/app/app/src/main/res/values-night/themes.xml
@@ -3,7 +3,8 @@
         <item name="appBarLayoutStyle">@style/Widget.App.AppBarLayout</item>
         <item name="toolbarStyle">@style/Widget.App.Toolbar</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
-        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
+        <item name="android:statusBarColor">?attr/colorOnPrimary</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
         <!-- this can be used to customize backgrounds with images, otherwise it will use the default android:colorBackground value -->
         <item name="mainBackground">@drawable/bg_solid</item>
     </style>

--- a/app/app/src/main/res/values-night/themes.xml
+++ b/app/app/src/main/res/values-night/themes.xml
@@ -3,8 +3,7 @@
         <item name="appBarLayoutStyle">@style/Widget.App.AppBarLayout</item>
         <item name="toolbarStyle">@style/Widget.App.Toolbar</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
-        <item name="android:statusBarColor">?attr/colorOnPrimary</item>
-        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
         <!-- this can be used to customize backgrounds with images, otherwise it will use the default android:colorBackground value -->
         <item name="mainBackground">@drawable/bg_solid</item>
     </style>

--- a/app/app/src/main/res/values/themes.xml
+++ b/app/app/src/main/res/values/themes.xml
@@ -4,7 +4,7 @@
         <item name="appBarLayoutStyle">@style/Widget.App.AppBarLayout</item>
         <item name="toolbarStyle">@style/Widget.App.Toolbar</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
         <!-- this can be used to customize backgrounds with images, otherwise it will use the default android:colorBackground value -->
         <item name="mainBackground">@drawable/bg_solid</item>
     </style>

--- a/app/app/src/main/res/values/themes.xml
+++ b/app/app/src/main/res/values/themes.xml
@@ -3,6 +3,8 @@
     <style name="Theme.Unchained.Material3" parent="Theme.Material3.Light.NoActionBar">
         <item name="appBarLayoutStyle">@style/Widget.App.AppBarLayout</item>
         <item name="toolbarStyle">@style/Widget.App.Toolbar</item>
+        <item name="android:statusBarColor">?attr/colorOnPrimary</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
         <!-- this can be used to customize backgrounds with images, otherwise it will use the default android:colorBackground value -->
         <item name="mainBackground">@drawable/bg_solid</item>

--- a/app/app/src/main/res/values/themes.xml
+++ b/app/app/src/main/res/values/themes.xml
@@ -3,9 +3,8 @@
     <style name="Theme.Unchained.Material3" parent="Theme.Material3.Light.NoActionBar">
         <item name="appBarLayoutStyle">@style/Widget.App.AppBarLayout</item>
         <item name="toolbarStyle">@style/Widget.App.Toolbar</item>
-        <item name="android:statusBarColor">?attr/colorOnPrimary</item>
-        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
         <!-- this can be used to customize backgrounds with images, otherwise it will use the default android:colorBackground value -->
         <item name="mainBackground">@drawable/bg_solid</item>
     </style>


### PR DESCRIPTION
Fixes Top bar is covered by notification tray on Android 15 #408 (https://github.com/LivingWithHippos/unchained-android/issues/408). Issue confirmed on my Pixel 6 as well.