### PR TITLE
Fix folder list scroll during link fetching

### DIFF
--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/folderlist/view/FolderListFragment.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/folderlist/view/FolderListFragment.kt
@@ -236,15 +236,7 @@ class FolderListFragment : UnchainedFragment(), DownloadListListener {
 
         // observe the list loading status
         viewModel.folderLiveData.observe(viewLifecycleOwner) {
-            it.getContentIfNotHandled()?.let { _ ->
-                updateList(adapter)
-                // scroll only if the results are still coming in
-                if (viewModel.getScrollingAllowed()) {
-                    lifecycleScope.launch {
-                        binding.rvFolderList.delayedScrolling(requireContext(), delay = 500)
-                    }
-                }
-            }
+            it.getContentIfNotHandled()?.let { _ -> updateList(adapter) }
         }
 
         // observe errors

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/folderlist/viewmodel/FolderListViewModel.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/folderlist/viewmodel/FolderListViewModel.kt
@@ -74,7 +74,7 @@ constructor(
                         }
                         is EitherResult.Success -> {
                             hitList.add(file.success)
-                            folderLiveData.postEvent(hitList)
+                            folderLiveData.postEvent(hitList.toList())
                             setRetrievedLinks(hitList.size)
                             progressLiveData.postValue((index + 1) * 100 / links.size)
                         }


### PR DESCRIPTION
Fixes #465

Remove automatic scroll-to-top during incremental folder list updates because it resets the user’s scroll position while torrent links are still loading.
Also emit immutable snapshots of the fetched link list to avoid mutable list reuse during UI updates.