### PR TITLE
feat: cache unrestricted links in memory

### DIFF
--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/repository/DownloadRepository.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/repository/DownloadRepository.kt
@@ -7,8 +7,11 @@ import javax.inject.Inject
 
 class DownloadRepository
 @Inject
-constructor(protoStore: ProtoStore, private val downloadApiHelper: DownloadApiHelper) :
-    BaseRepository(protoStore) {
+constructor(
+    protoStore: ProtoStore,
+    private val downloadApiHelper: DownloadApiHelper,
+    private val unrestrictRepository: UnrestrictRepository,
+) : BaseRepository(protoStore) {
     suspend fun getDownloads(offset: Int?, page: Int = 1, limit: Int = 50): List<DownloadItem> {
 
         val downloadResponse =
@@ -31,6 +34,10 @@ constructor(protoStore: ProtoStore, private val downloadApiHelper: DownloadApiHe
                 },
                 errorMessage = "Error deleting download",
             )
+
+        if (response != null) {
+            unrestrictRepository.clearUnrestrictedLinkCache()
+        }
 
         return response
     }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/data/repository/UnrestrictRepository.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/data/repository/UnrestrictRepository.kt
@@ -1,20 +1,29 @@
 package com.github.livingwithhippos.unchained.data.repository
 
+import android.os.SystemClock
+import android.util.LruCache
 import com.github.livingwithhippos.unchained.data.local.ProtoStore
 import com.github.livingwithhippos.unchained.data.model.DownloadItem
 import com.github.livingwithhippos.unchained.data.model.UnchainedNetworkException
 import com.github.livingwithhippos.unchained.data.remote.UnrestrictApiHelper
 import com.github.livingwithhippos.unchained.utilities.EitherResult
 import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.delay
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 
+@Singleton
 class UnrestrictRepository
 @Inject
 constructor(protoStore: ProtoStore, private val unrestrictApiHelper: UnrestrictApiHelper) :
     BaseRepository(protoStore) {
+
+    private val unrestrictedLinkCache =
+        LruCache<UnrestrictedLinkCacheKey, CachedUnrestrictedLink>(
+            UNRESTRICTED_LINK_CACHE_MAX_ENTRIES
+        )
 
     suspend fun getEitherUnrestrictedLink(
         link: String,
@@ -22,6 +31,11 @@ constructor(protoStore: ProtoStore, private val unrestrictApiHelper: UnrestrictA
         remote: Int? = null,
     ): EitherResult<UnchainedNetworkException, DownloadItem> {
         val token = getToken()
+        val cacheKey = UnrestrictedLinkCacheKey(link = link, password = password, remote = remote)
+
+        getCachedUnrestrictedLink(cacheKey)?.let {
+            return EitherResult.Success(it)
+        }
 
         val linkResponse =
             eitherApiResult(
@@ -36,7 +50,15 @@ constructor(protoStore: ProtoStore, private val unrestrictApiHelper: UnrestrictA
                 errorMessage = "Error Fetching Unrestricted Link Info",
             )
 
+        if (linkResponse is EitherResult.Success) {
+            cacheUnrestrictedLink(cacheKey, linkResponse.success)
+        }
+
         return linkResponse
+    }
+
+    fun clearUnrestrictedLinkCache() {
+        synchronized(unrestrictedLinkCache) { unrestrictedLinkCache.evictAll() }
     }
 
     suspend fun getUnrestrictedLinkList(
@@ -109,5 +131,46 @@ constructor(protoStore: ProtoStore, private val unrestrictApiHelper: UnrestrictA
             )
 
         return containerResponse
+    }
+
+    private fun cacheUnrestrictedLink(key: UnrestrictedLinkCacheKey, item: DownloadItem) {
+        synchronized(unrestrictedLinkCache) {
+            unrestrictedLinkCache.put(
+                key,
+                CachedUnrestrictedLink(
+                    item = item,
+                    createdAtElapsedRealtime = SystemClock.elapsedRealtime(),
+                ),
+            )
+        }
+    }
+
+    private fun getCachedUnrestrictedLink(key: UnrestrictedLinkCacheKey): DownloadItem? =
+        synchronized(unrestrictedLinkCache) {
+            val cachedLink = unrestrictedLinkCache.get(key) ?: return@synchronized null
+            val cacheAge = SystemClock.elapsedRealtime() - cachedLink.createdAtElapsedRealtime
+
+            if (cacheAge <= UNRESTRICTED_LINK_CACHE_TTL_MS) {
+                cachedLink.item
+            } else {
+                unrestrictedLinkCache.remove(key)
+                null
+            }
+        }
+
+    private data class UnrestrictedLinkCacheKey(
+        val link: String,
+        val password: String?,
+        val remote: Int?,
+    )
+
+    private data class CachedUnrestrictedLink(
+        val item: DownloadItem,
+        val createdAtElapsedRealtime: Long,
+    )
+
+    companion object {
+        private const val UNRESTRICTED_LINK_CACHE_MAX_ENTRIES = 5000
+        private const val UNRESTRICTED_LINK_CACHE_TTL_MS = 2 * 60 * 60 * 1000L
     }
 }


### PR DESCRIPTION
Adds an in-memory cache for unrestricted links so returning to torrent/folder file lists does not refetch every link from scratch. Cached results are kept for 2 hours, survive screen navigation while the app is running, and are cleared after download deletes to avoid reusing stale item ids.

https://github.com/user-attachments/assets/d31ea85e-e56b-4367-80e3-05a321e947ac

Related #465