### PR TITLE
Add scroll to top button to the lists screen

### DIFF
--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/lists/view/ListsTabFragment.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/lists/view/ListsTabFragment.kt
@@ -175,6 +175,10 @@ class ListsTabFragment : UnchainedFragment() {
             findNavController().navigate(action)
         }
 
+        binding.fabScrollToTop.setOnClickListener {
+            viewModel.postScrollToTop(binding.tabs.selectedTabPosition)
+        }
+
         // an external link has been shared with the app
         activityViewModel.externalLinkLiveData.observe(
             viewLifecycleOwner,
@@ -624,6 +628,15 @@ class DownloadsListFragment : UnchainedFragment(), DownloadListListener {
             },
         )
 
+        // scroll the list to the top when the parent fragment fab is clicked on this tab
+        viewModel.scrollToTopLiveData.observe(viewLifecycleOwner) { event ->
+            if (event?.peekContent() == DOWNLOADS_TAB) {
+                event.getContentIfNotHandled()?.let {
+                    if (_binding != null) binding.rvDownloadList.layoutManager?.scrollToPosition(0)
+                }
+            }
+        }
+
         // starts the Transformations.switchMap(queryLiveData) which otherwise won't trigger the
         // Paging
         // request
@@ -834,6 +847,15 @@ class TorrentsListFragment : UnchainedFragment(), TorrentListListener {
                 }
             },
         )
+
+        // scroll the list to the top when the parent fragment fab is clicked on this tab
+        viewModel.scrollToTopLiveData.observe(viewLifecycleOwner) { event ->
+            if (event?.peekContent() == TORRENTS_TAB) {
+                event.getContentIfNotHandled()?.let {
+                    if (_binding != null) binding.rvTorrentList.layoutManager?.scrollToPosition(0)
+                }
+            }
+        }
 
         return binding.root
     }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/lists/viewmodel/ListTabsViewModel.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/lists/viewmodel/ListTabsViewModel.kt
@@ -79,6 +79,9 @@ constructor(
 
     val eventLiveData = MutableLiveData<Event<ListEvent>>()
 
+    // tab index of the list to be scrolled to the top, see ListsTabFragment fabScrollToTop
+    val scrollToTopLiveData = MutableLiveData<Event<Int>>()
+
     /**
      * Un restrict a torrent and move it to the download section
      *
@@ -176,6 +179,10 @@ constructor(
 
     fun postEventNotice(event: ListEvent) {
         eventLiveData.postEvent(event)
+    }
+
+    fun postScrollToTop(tab: Int) {
+        scrollToTopLiveData.postEvent(tab)
     }
 
     companion object {

--- a/app/app/src/main/res/drawable/icon_arrow_upward.xml
+++ b/app/app/src/main/res/drawable/icon_arrow_upward.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8L4,12z"/>
+</vector>

--- a/app/app/src/main/res/layout/fragment_tab_lists.xml
+++ b/app/app/src/main/res/layout/fragment_tab_lists.xml
@@ -25,6 +25,18 @@
         app:layout_constraintTop_toBottomOf="@id/tabs" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabScrollToTop"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="15dp"
+        android:contentDescription="@string/scroll_to_top"
+        app:fabSize="mini"
+        app:layout_constraintBottom_toTopOf="@id/fabNewDownload"
+        app:layout_constraintEnd_toEndOf="@id/fabNewDownload"
+        app:layout_constraintStart_toStartOf="@id/fabNewDownload"
+        app:srcCompat="@drawable/icon_arrow_upward" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fabNewDownload"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/app/src/main/res/layout/fragment_tab_lists.xml
+++ b/app/app/src/main/res/layout/fragment_tab_lists.xml
@@ -30,6 +30,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="15dp"
         android:contentDescription="@string/scroll_to_top"
+        android:nextFocusDown="@id/fabNewDownload"
         app:fabSize="mini"
         app:layout_constraintBottom_toTopOf="@id/fabNewDownload"
         app:layout_constraintEnd_toEndOf="@id/fabNewDownload"
@@ -43,6 +44,7 @@
         android:layout_marginEnd="10dp"
         android:layout_marginBottom="10dp"
         android:contentDescription="@string/new_download"
+        android:nextFocusUp="@id/fabScrollToTop"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:srcCompat="@drawable/icon_add" />

--- a/app/app/src/main/res/values-es/strings.xml
+++ b/app/app/src/main/res/values-es/strings.xml
@@ -20,6 +20,7 @@
     <string name="premium_days_format">Días restantes: %1$d</string>
     <string name="user">Usuario</string>
     <string name="new_download">Nueva descarga</string>
+    <string name="scroll_to_top">Desplázate hasta la parte superior</string>
     <string name="remote_traffic">Tráfico remoto</string>
     <string name="password_optional">Contraseña [Opcional]</string>
     <string name="yes">Sí</string>

--- a/app/app/src/main/res/values-fr/strings.xml
+++ b/app/app/src/main/res/values-fr/strings.xml
@@ -20,6 +20,7 @@
     <string name="premium_days_format">Jours restants : %1$d</string>
     <string name="user">Utilisateur</string>
     <string name="new_download">Nouveau téléchargement</string>
+    <string name="scroll_to_top">Remontez en haut de la page</string>
     <string name="remote_traffic">Trafic réseau</string>
     <string name="password_optional">Mot de passe [facultatif]</string>
     <string name="yes">Oui</string>

--- a/app/app/src/main/res/values-it/strings.xml
+++ b/app/app/src/main/res/values-it/strings.xml
@@ -20,6 +20,7 @@
     <string name="premium_days_format">Giorni rimanenti: %1$d</string>
     <string name="user">Utente</string>
     <string name="new_download">Nuovo Download</string>
+    <string name="scroll_to_top">Torna all\'inizio della pagina</string>
     <string name="remote_traffic">Traffico Remoto</string>
     <string name="password_optional">Password [opzionale]</string>
     <string name="yes">Sì</string>

--- a/app/app/src/main/res/values-ko/strings.xml
+++ b/app/app/src/main/res/values-ko/strings.xml
@@ -19,6 +19,7 @@
     <string name="premium_days_format">남은 기간: %1$d일</string>
     <string name="user">사용자</string>
     <string name="new_download">새 다운로드</string>
+    <string name="scroll_to_top">맨 위로 스크롤하기</string>
     <string name="remote_traffic">원격 트래픽</string>
     <string name="password_optional">비밀번호 [선택 사항]</string>
     <string name="yes">예</string>

--- a/app/app/src/main/res/values-tr/strings.xml
+++ b/app/app/src/main/res/values-tr/strings.xml
@@ -19,6 +19,7 @@
     <string name="premium_days_format">Kalan günler: %1$d</string>
     <string name="user">Kullanıcı</string>
     <string name="new_download">Yeni İndirme</string>
+    <string name="scroll_to_top">Sayfanın en üstüne git</string>
     <string name="remote_traffic">Uzak Trafik</string>
     <string name="password_optional">Parola [İsteğe Bağlı]</string>
     <string name="yes">Evet</string>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="premium_days_format">Remaining days: %1$d</string>
     <string name="user">User</string>
     <string name="new_download">New Download</string>
+    <string name="scroll_to_top">Scroll to the top</string>
     <string name="remote_traffic">Remote Traffic</string>
     <string name="password_optional">Password [Optional]</string>
     <string name="yes">Yes</string>


### PR DESCRIPTION
Adds a smaller fab above the new download one on the downloads/torrents screen, like suggested in #343. Tapping it scrolls the list of the current tab back to the top.

Closes #343