### PR TITLE
Skip the release build job on pull requests from forks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,9 @@ jobs:
         run: ./gradlew ktfmtCheck
   build:
     runs-on: ubuntu-latest
+    # skip on pull requests from forks: they cannot access the signing keystore
+    # secrets, so assembleRelease always fails there. build-debug still runs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
The build job signs a release apk with the keystore from the repo secrets. Secrets are not available to pull requests coming from forks, so the decoded release.pfk is empty and assembleRelease always fails with a signing error there (see the checks on #471, #472, #473 for example). This makes every external PR show a red cross even when the code is fine.

This skips the release job for fork PRs while keeping it for pushes and same-repo PRs. Fork PRs are still covered by the linter and the debug build.