### PR TITLE
Allow using search without being logged in

### DIFF
--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
@@ -301,8 +301,9 @@ class MainActivity : AppCompatActivity() {
                         null -> showToast(R.string.retry_later)
                     }
                     // this state should be managed by the fragments directly
+                    // the search tab is left enabled since it can be used without login, see #302
                     lifecycleScope.launch {
-                        disableBottomNavItems(R.id.navigation_lists, R.id.navigation_search)
+                        disableBottomNavItems(R.id.navigation_lists)
                         doubleClickBottomItem(R.id.navigation_home)
                     }
                 }
@@ -310,7 +311,8 @@ class MainActivity : AppCompatActivity() {
         }
 
         // disable the bottom menu items before loading the credentials
-        disableBottomNavItems(R.id.navigation_lists, R.id.navigation_search)
+        // the search tab is left enabled since it can be used without login, see #302
+        disableBottomNavItems(R.id.navigation_lists)
 
         // to avoid issues with restoring the app state we check the current state before calling
         // this


### PR DESCRIPTION
The search tab was disabled until the user logged in, even though the plugin-based scraper search itself never touches the Real-Debrid API. Removed it from the list of bottom nav items that get disabled before authentication, matching what the maintainer suggested in the issue.

Tapping a search result to download still needs a login, and falls back to the existing "please login" message instead of doing anything else, so this is a partial fix as expected, just enough to make the tab itself usable.

Closes #302