### PR TITLE
Apply theme changes instantly instead of requiring a restart

### DIFF
--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/base/ThemingCallback.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/base/ThemingCallback.kt
@@ -13,20 +13,41 @@ import com.github.livingwithhippos.unchained.settings.view.SettingsFragment.Comp
 import com.github.livingwithhippos.unchained.settings.view.SettingsFragment.Companion.THEME_NIGHT
 import com.github.livingwithhippos.unchained.settings.view.ThemeItem
 import com.github.livingwithhippos.unchained.utilities.extension.getThemeList
+import java.util.WeakHashMap
 
 class ThemingCallback(val preferences: SharedPreferences) : Application.ActivityLifecycleCallbacks {
 
+    // theme resource id each currently alive activity was (re)created with, so a change made
+    // while another activity is on top can be detected and applied on resume, see #305
+    private val appliedThemes = WeakHashMap<Activity, Int>()
+
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        val themeRes =
-            preferences.getInt(
-                SettingsFragment.KEY_THEME_NEW,
-                R.style.Theme_Unchained_Material3_Green_One,
-            )
+        val themeRes = currentThemeRes()
         val themesList = activity.applicationContext.getThemeList()
         val currentTheme: ThemeItem = themesList.find { it.themeID == themeRes } ?: themesList[1]
         setupNightMode(currentTheme.nightMode)
-        if (activity is AppCompatActivity) setCustomTheme(activity, themeRes)
+        if (activity is AppCompatActivity) {
+            setCustomTheme(activity, themeRes)
+            appliedThemes[activity] = themeRes
+        }
     }
+
+    override fun onActivityResumed(activity: Activity) {
+        if (activity !is AppCompatActivity) return
+        val themeRes = currentThemeRes()
+        val appliedThemeRes = appliedThemes[activity]
+        if (appliedThemeRes != null && appliedThemeRes != themeRes) {
+            // avoid re-triggering on the recreated instance's own resume
+            appliedThemes.remove(activity)
+            activity.recreate()
+        }
+    }
+
+    private fun currentThemeRes(): Int =
+        preferences.getInt(
+            SettingsFragment.KEY_THEME_NEW,
+            R.style.Theme_Unchained_Material3_Green_One,
+        )
 
     private fun setCustomTheme(activity: Activity, themeRes: Int) {
         activity.setTheme(themeRes)
@@ -39,15 +60,15 @@ class ThemingCallback(val preferences: SharedPreferences) : Application.Activity
 
     override fun onActivityStarted(activity: Activity) {}
 
-    override fun onActivityResumed(activity: Activity) {}
-
     override fun onActivityPaused(activity: Activity) {}
 
     override fun onActivityStopped(activity: Activity) {}
 
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
 
-    override fun onActivityDestroyed(activity: Activity) {}
+    override fun onActivityDestroyed(activity: Activity) {
+        appliedThemes.remove(activity)
+    }
 
     /** Set the night mode depending on the user preferences and what the theme support */
     private fun setupNightMode(themeNightModeSupport: String) {

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/settings/view/ThemePickerDialog.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/settings/view/ThemePickerDialog.kt
@@ -16,7 +16,6 @@ import com.github.livingwithhippos.unchained.R
 import com.github.livingwithhippos.unchained.databinding.ItemThemeListBinding
 import com.github.livingwithhippos.unchained.settings.viewmodel.SettingsViewModel
 import com.github.livingwithhippos.unchained.utilities.extension.getThemeList
-import com.github.livingwithhippos.unchained.utilities.extension.showToast
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -50,8 +49,8 @@ class ThemePickerDialog : DialogFragment(), ThemePickListener {
                 it.getContentIfNotHandled()?.let { theme ->
                     label.text = theme.name
                     viewModel.applyTheme()
-                    context?.showToast(R.string.restart_to_apply)
                     dialog?.cancel()
+                    activity?.recreate()
                 }
             }
 

--- a/app/app/src/main/res/values-es/strings.xml
+++ b/app/app/src/main/res/values-es/strings.xml
@@ -182,7 +182,6 @@
     <string name="share">Compartir</string>
     <string name="share_with">Comparte el enlace de descarga a través de:</string>
     <string name="share_all_with">Comparte todos los enlaces de descarga a través de:</string>
-    <string name="restart_to_apply">Reiniciar para aplicar</string>
     <string name="remove">Eliminar</string>
     <string name="confirm_download_removal_description">¿Está seguro de que quiere eliminar la descarga? Esta acción no se puede deshacer.</string>
     <string name="yes_remove">Sí, quítalo</string>

--- a/app/app/src/main/res/values-fr/strings.xml
+++ b/app/app/src/main/res/values-fr/strings.xml
@@ -182,7 +182,6 @@
     <string name="share">Partager</string>
     <string name="share_with">Partager le lien de téléchargement via:</string>
     <string name="share_all_with">Partagez tous les liens de téléchargement via:</string>
-    <string name="restart_to_apply">Redémarrer pour appliquer les modifications</string>
     <string name="remove">Supprimer</string>
     <string name="confirm_download_removal_description">Êtes-vous bien sûr de vouloir supprimer ce téléchargement ? Cette action est irréversible.</string>
     <string name="yes_remove">Oui, supprimez-le</string>

--- a/app/app/src/main/res/values-it/strings.xml
+++ b/app/app/src/main/res/values-it/strings.xml
@@ -182,7 +182,6 @@
     <string name="share">Condividi</string>
     <string name="share_with">Condividi link di download tramite:</string>
     <string name="share_all_with">Condividi tutti i links di download tramite:</string>
-    <string name="restart_to_apply">Riavvia per applicare</string>
     <string name="remove">Rimuovi</string>
     <string name="confirm_download_removal_description">Sei sicuro di voler rimuovere il download? Questa azione non può essere annullata.</string>
     <string name="yes_remove">Sì, rimuovilo</string>

--- a/app/app/src/main/res/values-ko/strings.xml
+++ b/app/app/src/main/res/values-ko/strings.xml
@@ -184,7 +184,6 @@
     <string name="share">공유</string>
     <string name="share_with">다음으로 다운로드 링크 공유:</string>
     <string name="share_all_with">다음으로 모든 다운로드 링크 공유:</string>
-    <string name="restart_to_apply">재시작하여 적용</string>
     <string name="remove">제거</string>
     <string name="confirm_download_removal_description">정말로 이 다운로드를 제거하시겠습니까? 이 작업은 되돌릴 수 없습니다.</string>
     <string name="yes_remove">네, 제거합니다</string>

--- a/app/app/src/main/res/values-tr/strings.xml
+++ b/app/app/src/main/res/values-tr/strings.xml
@@ -184,7 +184,6 @@
     <string name="share">Paylaş</string>
     <string name="share_with">İndirme bağlantısını şununla paylaş:</string>
     <string name="share_all_with">Tüm indirme bağlantılarını şununla paylaş:</string>
-    <string name="restart_to_apply">Uygulamak için yeniden başlat</string>
     <string name="remove">Kaldır</string>
     <string name="confirm_download_removal_description">İndirmeyi kaldırmak istediğinizden emin misiniz? Bu işlem geri alınamaz.</string>
     <string name="yes_remove">Evet, kaldır</string>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -395,7 +395,6 @@
     <string name="share">Share</string>
     <string name="share_with">Share download link via:</string>
     <string name="share_all_with">Share all download links via:</string>
-    <string name="restart_to_apply">Restart to apply</string>
     <string name="remove">Remove</string>
     <string name="confirm_download_removal_description">Are you sure you want to remove the download? This action cannot be undone.</string>
     <string name="yes_remove">Yes, remove it</string>

--- a/app/app/src/main/res/xml/settings.xml
+++ b/app/app/src/main/res/xml/settings.xml
@@ -2,9 +2,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <PreferenceCategory
-        android:summary="@string/restart_to_apply"
-        android:title="@string/title_aspect">
+    <PreferenceCategory android:title="@string/title_aspect">
 
         <Preference
             app:key="selected_theme"


### PR DESCRIPTION
Picking a new theme in Settings used to just save the preference and show a toast telling you to restart the app for it to take effect. Now it recreates the current screen right away, so the change shows immediately.

Since the app has two activities, the settings screen and the main one, ThemingCallback also checks on every screen resume whether the saved theme has changed since that screen was created, and recreates it too. That way going back from Settings to the main screen already shows the new theme instead of needing a full app restart.

Removed the now incorrect "restart to apply" text since it no longer applies.