### PR TITLE
Move cache clearing off the main thread

### DIFF
--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/start/viewmodel/MainActivityViewModel.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/start/viewmodel/MainActivityViewModel.kt
@@ -68,6 +68,7 @@ import java.io.File
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.firstOrNull
@@ -909,7 +910,9 @@ constructor(
     ) = customDownloadRepository.downloadToCache(link, fileName, cacheDir, suffix).asLiveData()
 
     fun clearCache(cacheDir: File) {
-        cacheDir.listFiles()?.forEach { if (it.name != "image_cache") it.deleteRecursively() }
+        viewModelScope.launch(Dispatchers.IO) {
+            cacheDir.listFiles()?.forEach { if (it.name != "image_cache") it.deleteRecursively() }
+        }
     }
 
     private fun checkUpdateVersion(


### PR DESCRIPTION
MainActivityViewModel.clearCache does a recursive delete over the cache directory, and it was running synchronously on whatever thread called it, which in this case is the main thread on every app start. Wrapped it in viewModelScope.launch(Dispatchers.IO) so the disk work happens off the main thread. As the cache grows this was a real path to startup jank.