### PR TITLE
Stop torrent status polling from outliving its screen

### DIFF
--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/viewmodel/TorrentDetailsViewModel.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentdetails/viewmodel/TorrentDetailsViewModel.kt
@@ -15,7 +15,6 @@ import com.github.livingwithhippos.unchained.utilities.extension.cancelIfActive
 import com.github.livingwithhippos.unchained.utilities.postEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -37,7 +36,7 @@ constructor(
     val downloadLiveData = MutableLiveData<Event<DownloadItem?>>()
     val errorsLiveData = MutableLiveData<Event<List<UnchainedNetworkException>>>()
 
-    private var job = Job()
+    private var job: Job? = null
 
     fun getFullTorrentInfo(id: String) {
         viewModelScope.launch {
@@ -48,21 +47,19 @@ constructor(
 
     fun pollTorrentStatus(id: String) {
         // todo: test if I need to recreate a job when it is cancelled
-        job.cancelIfActive()
-        job = Job()
+        job?.cancelIfActive()
 
-        val scope = CoroutineScope(job + Dispatchers.IO)
+        job =
+            viewModelScope.launch(Dispatchers.IO) {
+                // / maybe job.isActive?
+                while (isActive) {
+                    val torrentData = torrentsRepository.getTorrentInfo(id)
+                    if (torrentData != null) torrentLiveData.postEvent(torrentData)
+                    if (endedStatusList.contains(torrentData?.status)) job?.cancelIfActive()
 
-        scope.launch {
-            // / maybe job.isActive?
-            while (isActive) {
-                val torrentData = torrentsRepository.getTorrentInfo(id)
-                if (torrentData != null) torrentLiveData.postEvent(torrentData)
-                if (endedStatusList.contains(torrentData?.status)) job.cancelIfActive()
-
-                delay(2000.milliseconds)
+                    delay(2000.milliseconds)
+                }
             }
-        }
     }
 
     fun deleteTorrent(id: String) {

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentfilepicker/viewmodel/TorrentProcessingViewModel.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/torrentfilepicker/viewmodel/TorrentProcessingViewModel.kt
@@ -18,7 +18,6 @@ import com.github.livingwithhippos.unchained.utilities.extension.cancelIfActive
 import com.github.livingwithhippos.unchained.utilities.postEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -39,7 +38,7 @@ constructor(
     val torrentLiveData = MutableLiveData<Event<TorrentEvent>>()
     val structureLiveData = MutableLiveData<Event<Node<TorrentFileItem>>>()
 
-    private var job = Job()
+    private var job: Job? = null
 
     fun fetchAddedMagnet(magnet: String) {
         viewModelScope.launch {
@@ -103,48 +102,46 @@ constructor(
             return
         }
 
-        job.cancelIfActive()
-        job = Job()
+        job?.cancelIfActive()
 
-        val scope = CoroutineScope(job + Dispatchers.IO)
-
-        scope.launch {
-            var selected = false
-            // / maybe job.isActive?
-            while (isActive) {
-                if (!selected) {
-                    when (val selectResponse = torrentsRepository.selectFiles(id, files)) {
-                        is EitherResult.Failure -> {
-                            if (selectResponse.failure is EmptyBodyError) {
-                                Timber.d(
-                                    "Select torrent files success returned ${selectResponse.failure.returnCode}"
-                                )
+        job =
+            viewModelScope.launch(Dispatchers.IO) {
+                var selected = false
+                // / maybe job.isActive?
+                while (isActive) {
+                    if (!selected) {
+                        when (val selectResponse = torrentsRepository.selectFiles(id, files)) {
+                            is EitherResult.Failure -> {
+                                if (selectResponse.failure is EmptyBodyError) {
+                                    Timber.d(
+                                        "Select torrent files success returned ${selectResponse.failure.returnCode}"
+                                    )
+                                    selected = true
+                                } else {
+                                    Timber.e(
+                                        "Exception during torrent files selection call: ${selectResponse.failure}"
+                                    )
+                                }
+                            }
+                            is EitherResult.Success -> {
+                                Timber.d("Select torrent files success")
                                 selected = true
-                            } else {
-                                Timber.e(
-                                    "Exception during torrent files selection call: ${selectResponse.failure}"
-                                )
                             }
                         }
-                        is EitherResult.Success -> {
-                            Timber.d("Select torrent files success")
-                            selected = true
-                        }
                     }
-                }
 
-                if (selected) {
-                    val torrentItem: TorrentItem? = torrentsRepository.getTorrentInfo(id)
-                    if (torrentItem != null) {
-                        if (!beforeSelectionStatusList.contains(torrentItem.status)) {
-                            job.cancelIfActive()
-                            torrentLiveData.postEvent(TorrentEvent.FilesSelected(torrentItem))
+                    if (selected) {
+                        val torrentItem: TorrentItem? = torrentsRepository.getTorrentInfo(id)
+                        if (torrentItem != null) {
+                            if (!beforeSelectionStatusList.contains(torrentItem.status)) {
+                                job?.cancelIfActive()
+                                torrentLiveData.postEvent(TorrentEvent.FilesSelected(torrentItem))
+                            }
                         }
                     }
+                    delay(1500.milliseconds)
                 }
-                delay(1500.milliseconds)
             }
-        }
     }
 
     fun triggerTorrentEvent(event: TorrentEvent) {


### PR DESCRIPTION
TorrentDetailsViewModel and TorrentProcessingViewModel each created their own CoroutineScope for polling torrent status instead of using viewModelScope, and nothing ever cancelled it if you navigated away before the polling loop's own stop condition was reached. That left it polling the API in the background indefinitely, using battery and data with no way for the user to know why. Switched both to viewModelScope, which gets cancelled automatically when the screen is left.