### PR TITLE
Cancel active downloads on network change

### DIFF
--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/base/UnchainedApplication.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/base/UnchainedApplication.kt
@@ -14,6 +14,7 @@ import com.github.livingwithhippos.unchained.data.model.Repository
 import com.github.livingwithhippos.unchained.data.repository.ServiceRepository
 import com.github.livingwithhippos.unchained.utilities.DEFAULT_PLUGINS_REPOSITORY_LINK
 import com.github.livingwithhippos.unchained.utilities.TelemetryManager
+import com.github.livingwithhippos.unchained.utilities.download.NetworkChangeDownloadCanceller
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -37,6 +38,7 @@ class UnchainedApplication : Application() {
     @Inject lateinit var pluginRepositoryDataDao: RepositoryDataDao
     @Inject lateinit var legacyServiceRepository: RemoteDeviceDao
     @Inject lateinit var newServiceRepository: ServiceRepository
+    @Inject lateinit var networkChangeDownloadCanceller: NetworkChangeDownloadCanceller
 
     private val job = Job()
     private val scope = CoroutineScope(Dispatchers.Default + job)
@@ -45,6 +47,8 @@ class UnchainedApplication : Application() {
         super.onCreate()
 
         registerActivityLifecycleCallbacks(activityCallback)
+
+        networkChangeDownloadCanceller.start()
 
         scope.launch {
             protoStore.deleteIncompleteCredentials()

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/start/viewmodel/MainActivityViewModel.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/start/viewmodel/MainActivityViewModel.kt
@@ -51,6 +51,7 @@ import com.github.livingwithhippos.unchained.statemachine.authentication.Current
 import com.github.livingwithhippos.unchained.statemachine.authentication.FSMAuthenticationEvent
 import com.github.livingwithhippos.unchained.statemachine.authentication.FSMAuthenticationSideEffect
 import com.github.livingwithhippos.unchained.statemachine.authentication.FSMAuthenticationState
+import com.github.livingwithhippos.unchained.utilities.EMBEDDED_DOWNLOAD_WORK_TAG
 import com.github.livingwithhippos.unchained.utilities.EitherResult
 import com.github.livingwithhippos.unchained.utilities.Event
 import com.github.livingwithhippos.unchained.utilities.MAGNET_PATTERN
@@ -1038,6 +1039,7 @@ constructor(
         val downloadFileRequest =
             OneTimeWorkRequestBuilder<DownloadWorker>()
                 .addTag(content.source)
+                .addTag(EMBEDDED_DOWNLOAD_WORK_TAG)
                 .setInputData(data)
                 .setConstraints(constraints)
                 .build()
@@ -1074,6 +1076,7 @@ constructor(
                 .setInputData(data)
                 .setConstraints(constraints)
                 .addTag(it.download)
+                .addTag(EMBEDDED_DOWNLOAD_WORK_TAG)
                 .build()
         }
 

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/Constants.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/Constants.kt
@@ -19,6 +19,10 @@ const val MANUAL_PLUGINS_REPOSITORY_NAME = "common_repository"
 // unofficial link to get streaming from a browser page
 const val RD_STREAMING_URL = "https://real-debrid.com/streaming-"
 
+// shared WorkManager tag added to every embedded (OkHttp) download request, alongside its
+// per-source tag, so all active downloads can be cancelled together on a network change
+const val EMBEDDED_DOWNLOAD_WORK_TAG = "embedded_download"
+
 const val PRIVATE_TOKEN: String = "private_token"
 
 const val REMOTE_TRAFFIC_ON: Int = 1
@@ -122,6 +126,7 @@ object PreferenceKeys {
         const val OKHTTP = "download_manager_okhttp"
         const val UNMETERED_ONLY_KEY = "download_only_on_unmetered"
         const val VIBRATE_ON_FINISH = "vibrate_on_download"
+        const val PAUSE_ON_NETWORK_CHANGE_KEY = "pause_downloads_on_network_change"
     }
 
     object Ui {

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/download/NetworkChangeDownloadCanceller.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/download/NetworkChangeDownloadCanceller.kt
@@ -1,0 +1,62 @@
+package com.github.livingwithhippos.unchained.utilities.download
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.ConnectivityManager
+import android.net.Network
+import androidx.work.WorkManager
+import com.github.livingwithhippos.unchained.utilities.EMBEDDED_DOWNLOAD_WORK_TAG
+import com.github.livingwithhippos.unchained.utilities.PreferenceKeys
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import timber.log.Timber
+
+/**
+ * Cancels active embedded (WorkManager/OkHttp) downloads whenever the default network changes,
+ * since continuing a Real-Debrid download from a different IP can get an account flagged. Opt-in
+ * via the [PreferenceKeys.DownloadManager.PAUSE_ON_NETWORK_CHANGE_KEY] setting.
+ *
+ * There is no download resume support anywhere in the app, so this cancels the transfer outright;
+ * the user has to restart it manually afterward.
+ *
+ * Registered once from [com.github.livingwithhippos.unchained.base.UnchainedApplication] instead
+ * of an Activity, since embedded downloads run in a foreground-service-backed WorkManager worker
+ * that can keep going while the app is backgrounded.
+ */
+@Singleton
+class NetworkChangeDownloadCanceller
+@Inject
+constructor(@ApplicationContext private val context: Context, private val preferences: SharedPreferences) {
+
+    // Android hands out a new Network instance for the new connection on almost any network
+    // switch, including reconnecting to the same wi-fi access point, so comparing instances is a
+    // reasonably safe proxy for "the IP address may have changed"
+    private var lastActiveNetwork: Network? = null
+
+    private val networkCallback =
+        object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                val previousNetwork = lastActiveNetwork
+                lastActiveNetwork = network
+                if (previousNetwork != null && previousNetwork != network) {
+                    onNetworkChanged()
+                }
+            }
+        }
+
+    fun start() {
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        connectivityManager.registerDefaultNetworkCallback(networkCallback)
+    }
+
+    private fun onNetworkChanged() {
+        val cancelOnNetworkChange =
+            preferences.getBoolean(PreferenceKeys.DownloadManager.PAUSE_ON_NETWORK_CHANGE_KEY, false)
+        if (!cancelOnNetworkChange) return
+
+        Timber.d("Default network changed, cancelling active embedded downloads")
+        WorkManager.getInstance(context).cancelAllWorkByTag(EMBEDDED_DOWNLOAD_WORK_TAG)
+    }
+}

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -647,6 +647,8 @@
     <string name="custom_downloader_options_description">These options are not available for the default download manager</string>
     <string name="unmetered_downloads">Downloads on unmetered connections</string>
     <string name="unmetered_downloads_description">Start downloads only on unmetered connection (such as wi-fi)</string>
+    <string name="pause_downloads_on_network_change">Cancel downloads on network change</string>
+    <string name="pause_downloads_on_network_change_description">Cancel active downloads if the network changes (e.g. wi-fi to mobile data), since Real-Debrid may flag your account for downloading from multiple IPs. Cancelled downloads must be restarted manually</string>
     <string name="download_on_metered_connection">Download delayed (metered connection)</string>
     <string name="leechers">Leechers</string>
     <string name="size">Size</string>

--- a/app/app/src/main/res/xml/settings.xml
+++ b/app/app/src/main/res/xml/settings.xml
@@ -51,6 +51,12 @@
             app:summary="@string/unmetered_downloads_description"
             app:title="@string/unmetered_downloads" />
 
+        <SwitchPreference
+            android:defaultValue="false"
+            app:key="pause_downloads_on_network_change"
+            app:summary="@string/pause_downloads_on_network_change_description"
+            app:title="@string/pause_downloads_on_network_change" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Real-Debrid can flag an account for downloading from multiple IPs, so this adds an opt-in
setting that cancels active embedded downloads whenever the device's default network changes,
like switching from wi-fi to mobile data.

A NetworkChangeDownloadCanceller is registered once from the Application class instead of an
Activity, since downloads run in a foreground-service-backed WorkManager worker that can keep
going while the app is backgrounded. It compares the Network instance Android hands back on
each connectivity change, and cancels every active download through a shared WorkManager tag
on an actual change, reusing the same stop mechanism already wired to the per-download
notification's Stop action.

There's no resume support anywhere in the download code, so this cancels the transfer outright
instead of pausing it; the user has to restart it manually, which the setting's description
says plainly.

The system download manager is left out of this since it only exposes enqueue/query/remove
with no pause-resume primitive, and the app currently discards the download IDs it would need
to cancel anything, matching what you were unsure about in the issue.

Closes #421