### PR TITLE
Make the app usable with a d-pad on Android TV

### DIFF
--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/base/MainActivity.kt
@@ -18,6 +18,8 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import android.view.View
+import android.view.ViewParent
 import android.widget.Toast
 import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
@@ -36,6 +38,8 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
 import com.github.livingwithhippos.unchained.BuildConfig
 import com.github.livingwithhippos.unchained.R
 import com.github.livingwithhippos.unchained.data.model.UserAction
@@ -59,6 +63,7 @@ import com.github.livingwithhippos.unchained.utilities.SCHEME_MAGNET
 import com.github.livingwithhippos.unchained.utilities.SIGNATURE
 import com.github.livingwithhippos.unchained.utilities.TelemetryManager
 import com.github.livingwithhippos.unchained.utilities.extension.downloadFileInStandardFolder
+import com.github.livingwithhippos.unchained.utilities.extension.isTv
 import com.github.livingwithhippos.unchained.utilities.extension.openExternalWebPage
 import com.github.livingwithhippos.unchained.utilities.extension.parcelable
 import com.github.livingwithhippos.unchained.utilities.extension.showToast
@@ -220,6 +225,10 @@ class MainActivity : AppCompatActivity() {
         setupBottomNavigationBar(binding)
 
         setupBackPressedHandling()
+
+        setupTvBackFocusHandling()
+
+        setupTvInitialFocusHandling()
 
         addMenuProvider(
             object : MenuProvider {
@@ -936,6 +945,50 @@ class MainActivity : AppCompatActivity() {
 
             exitCallback.isEnabled = onExitingFragment && backWouldExit
         }
+    }
+
+    /** On TV, a back press while focus is inside a long/endless list moves it to the bottom nav
+     * instead of navigating, since there is no other way to reach the nav bar from deep in a
+     * list (see issue #376). */
+    private fun setupTvBackFocusHandling() {
+        if (!isTv()) return
+
+        onBackPressedDispatcher.addCallback(this) {
+            val focusRescued =
+                currentFocus?.isInsideScrollableList() == true &&
+                    binding.bottomNavView.requestFocus()
+            if (!focusRescued) {
+                // let the other callbacks or the default handling manage this back press
+                isEnabled = false
+                onBackPressedDispatcher.onBackPressed()
+                isEnabled = true
+            }
+        }
+    }
+
+    /** On TV, the toolbar's overflow button is first in layout order and silently grabs default
+     * focus on every new destination. Rescue focus onto the bottom nav when that happens, without
+     * touching focus a fragment or back navigation already placed deliberately. */
+    private fun setupTvInitialFocusHandling() {
+        if (!isTv()) return
+
+        navController.addOnDestinationChangedListener { _, _, _ ->
+            binding.root.post {
+                if (binding.appBarLayout.findFocus() != null) {
+                    binding.bottomNavView.requestFocus()
+                }
+            }
+        }
+    }
+
+    /** True if inside a scrollable list, ignoring the RecyclerView ViewPager2 uses internally. */
+    private fun View.isInsideScrollableList(): Boolean {
+        var current: ViewParent? = parent
+        while (current != null) {
+            if (current is RecyclerView && current.parent !is ViewPager2) return true
+            current = current.parent
+        }
+        return false
     }
 
     private fun showUpdateDialog(description: String, link: String) {

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/lists/view/ListsTabFragment.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/lists/view/ListsTabFragment.kt
@@ -487,8 +487,7 @@ class DownloadsListFragment : UnchainedFragment(), DownloadListListener {
             // only in landscape view
             viewModel.postEventNotice(ListEvent.NewDownload)
         }
-        binding.bRefresh?.setOnClickListener {
-            // only in landscape view
+        binding.bRefresh.setOnClickListener {
             if (!binding.srLayout.isRefreshing) {
                 binding.srLayout.isRefreshing = true
                 downloadAdapter.refresh()
@@ -739,7 +738,7 @@ class TorrentsListFragment : UnchainedFragment(), TorrentListListener {
             // landscape only
             viewModel.postEventNotice(ListEvent.NewDownload)
         }
-        binding.bRefresh?.setOnClickListener {
+        binding.bRefresh.setOnClickListener {
             if (!binding.srLayout.isRefreshing) {
                 binding.srLayout.isRefreshing = true
                 torrentAdapter.refresh()

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/settings/view/CustomColorPickerDialog.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/settings/view/CustomColorPickerDialog.kt
@@ -17,6 +17,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.color.MaterialColors
 import com.google.android.material.slider.Slider
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -120,11 +121,24 @@ class CustomColorPickerDialog : BottomSheetDialogFragment() {
         val marginPx = resources.getDimensionPixelSize(R.dimen.custom_color_swatch_margin)
         return View(requireContext()).apply {
             layoutParams = LinearLayout.LayoutParams(sizePx, sizePx).apply { marginEnd = marginPx }
-            background =
+            val swatchDrawable =
                 GradientDrawable().apply {
                     shape = GradientDrawable.OVAL
                     setColor(color)
                 }
+            background = swatchDrawable
+            // plain Views are not reachable with a d-pad by default, so make the swatches
+            // focusable and show a ring around the focused one for TV and keyboard users
+            isFocusable = true
+            setOnFocusChangeListener { v, hasFocus ->
+                val strokeWidth =
+                    if (hasFocus) v.resources.getDimensionPixelSize(R.dimen.focus_stroke_width)
+                    else 0
+                swatchDrawable.setStroke(
+                    strokeWidth,
+                    MaterialColors.getColor(v, com.google.android.material.R.attr.colorOnSurface),
+                )
+            }
             setOnClickListener { onClick() }
         }
     }

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/NonFocusableNestedScrollView.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/NonFocusableNestedScrollView.kt
@@ -1,0 +1,30 @@
+package com.github.livingwithhippos.unchained.utilities
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.core.widget.NestedScrollView
+
+/**
+ * A [NestedScrollView] that never takes d-pad focus itself.
+ *
+ * NestedScrollView calls setFocusable(true) in its constructor, overriding any android:focusable
+ * attribute set in the layout. On Android TV this makes the scroll container itself a focus
+ * target: it sits directly next to the toolbar and the navigation bar, so FocusFinder routes the
+ * d-pad onto it instead of the buttons inside, and since a focused scroll view has no visual
+ * focus state the screen looks like it cannot be navigated at all (see issue #376).
+ *
+ * Focused children still scroll into view through requestChildFocus, so scrolling with the d-pad
+ * keeps working as long as the content contains at least one focusable view.
+ */
+class NonFocusableNestedScrollView
+@JvmOverloads
+constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = androidx.core.R.attr.nestedScrollViewStyle,
+) : NestedScrollView(context, attrs, defStyleAttr) {
+
+    init {
+        isFocusable = false
+    }
+}

--- a/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/extension/Extension.kt
+++ b/app/app/src/main/java/com/github/livingwithhippos/unchained/utilities/extension/Extension.kt
@@ -10,6 +10,7 @@ import android.content.ClipboardManager
 import android.content.ContentResolver.SCHEME_CONTENT
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.res.AssetManager
 import android.content.res.Configuration
 import android.content.res.Resources
@@ -364,6 +365,9 @@ fun Uri.getFileName(context: Context): String {
     }
     return fileName
 }
+
+/** True on Android TV, where several controls need d-pad-specific handling. */
+fun Context.isTv(): Boolean = packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
 
 /**
  * Open an url from available apps

--- a/app/app/src/main/res/color/focus_fill.xml
+++ b/app/app/src/main/res/color/focus_fill.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Translucent fill used inside the focus ring drawables so the whole control lights up
+     while focused, making the d-pad cursor easy to follow on Android TV from a distance. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.25" android:color="?attr/colorPrimary" />
+</selector>

--- a/app/app/src/main/res/color/focus_fill_on_container.xml
+++ b/app/app/src/main/res/color/focus_fill_on_container.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Translucent focus fill for controls on a colorPrimaryContainer background (fabs),
+     see focus_fill.xml. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.25" android:color="?attr/colorOnPrimaryContainer" />
+</selector>

--- a/app/app/src/main/res/color/focus_fill_on_primary.xml
+++ b/app/app/src/main/res/color/focus_fill_on_primary.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Translucent focus fill for controls on a colorPrimary background (the toolbar), see
+     focus_fill.xml. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.3" android:color="?attr/colorOnPrimary" />
+</selector>

--- a/app/app/src/main/res/color/list_card_stroke.xml
+++ b/app/app/src/main/res/color/list_card_stroke.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Stroke color for the list item cards: visible only while the card is focused,
+     e.g. when navigating with a d-pad on Android TV. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/colorPrimary" android:state_focused="true" />
+    <item android:color="@android:color/transparent" />
+</selector>

--- a/app/app/src/main/res/drawable/focus_ring_control.xml
+++ b/app/app/src/main/res/drawable/focus_ring_control.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Focus indicator overlay for small controls (checkboxes, switches, chips),
+     see focus_ring_pill.xml. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/focus_fill" />
+            <stroke android:width="@dimen/focus_stroke_width" android:color="?attr/colorPrimary" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/app/app/src/main/res/drawable/focus_ring_fab.xml
+++ b/app/app/src/main/res/drawable/focus_ring_fab.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Focus indicator overlay for floating action buttons, see focus_ring_pill.xml. FABs use the
+     16dp rounded square Material 3 shape and a colorPrimaryContainer background, so the ring
+     uses the matching on color to stay visible on top of it. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="16dp" />
+            <solid android:color="@color/focus_fill_on_container" />
+            <stroke
+                android:width="@dimen/focus_stroke_width"
+                android:color="?attr/colorOnPrimaryContainer" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/app/app/src/main/res/drawable/focus_ring_pill.xml
+++ b/app/app/src/main/res/drawable/focus_ring_pill.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Focus indicator overlay for pill shaped controls (buttons, icon buttons): a colored ring
+     that is only visible while the view is focused, e.g. when navigating with a d-pad on
+     Android TV. Used as android:foreground so it never interferes with the background ripple,
+     elevation or touch feedback. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="50dp" />
+            <solid android:color="@color/focus_fill" />
+            <stroke android:width="@dimen/focus_stroke_width" android:color="?attr/colorPrimary" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/app/app/src/main/res/drawable/focus_ring_toolbar.xml
+++ b/app/app/src/main/res/drawable/focus_ring_toolbar.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Focus indicator overlay for toolbar action icons (menu items, the overflow button), see
+     focus_ring_pill.xml. These sit on a colorPrimary background, so colorOnPrimary is used
+     instead of colorPrimary to stay visible, the same reasoning as focus_ring_fab.xml for fabs
+     on their own colored container. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="50dp" />
+            <solid android:color="@color/focus_fill_on_primary" />
+            <stroke android:width="@dimen/focus_stroke_width" android:color="?attr/colorOnPrimary" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/app/app/src/main/res/layout-land/fragment_downloads_list.xml
+++ b/app/app/src/main/res/layout-land/fragment_downloads_list.xml
@@ -26,6 +26,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="10dp"
+            android:nextFocusRight="@id/cbSelectAll"
+            android:nextFocusDown="@id/rvDownloadList"
             android:text="@string/add"
             app:icon="@drawable/icon_add" />
 
@@ -101,6 +103,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
+            android:nextFocusUp="@id/cbSelectAll"
             android:scrollbars="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/item_list_download" />

--- a/app/app/src/main/res/layout-land/fragment_torrents_list.xml
+++ b/app/app/src/main/res/layout-land/fragment_torrents_list.xml
@@ -26,7 +26,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="10dp"
             android:nextFocusRight="@id/cbSelectAll"
-            android:nextFocusDown="@id/rvDownloadList"
+            android:nextFocusDown="@id/rvTorrentList"
             android:text="@string/add"
             app:icon="@drawable/icon_add" />
 
@@ -36,7 +36,7 @@
             android:layout_height="wrap_content"
             android:checked="false"
             android:nextFocusRight="@id/bDeleteSelected"
-            android:nextFocusDown="@id/rvDownloadList"
+            android:nextFocusDown="@id/rvTorrentList"
             android:text="0"
             android:tooltipText="@string/select_deselect_all" />
 
@@ -47,7 +47,7 @@
             android:layout_height="wrap_content"
             android:contentDescription="@string/delete"
             android:nextFocusRight="@id/bDownloadSelected"
-            android:nextFocusDown="@id/rvDownloadList"
+            android:nextFocusDown="@id/rvTorrentList"
             android:tooltipText="@string/delete_selected"
             app:icon="@drawable/icon_delete"
             app:iconSize="25dp" />
@@ -59,7 +59,7 @@
             android:layout_height="wrap_content"
             android:contentDescription="@string/download"
             android:nextFocusRight="@id/bDetailsSelected"
-            android:nextFocusDown="@id/rvDownloadList"
+            android:nextFocusDown="@id/rvTorrentList"
             android:tooltipText="@string/download_selected"
             app:icon="@drawable/icon_download"
             app:iconSize="25dp" />
@@ -71,7 +71,7 @@
             android:layout_height="wrap_content"
             android:contentDescription="@string/torrent_details"
             android:nextFocusRight="@id/bRefresh"
-            android:nextFocusDown="@id/rvDownloadList"
+            android:nextFocusDown="@id/rvTorrentList"
             android:tooltipText="@string/torrent_details"
             app:icon="@drawable/icon_info"
             app:iconSize="25dp" />
@@ -82,8 +82,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/refresh"
-            android:nextFocusRight="@id/rvDownloadList"
-            android:nextFocusDown="@id/rvDownloadList"
+            android:nextFocusRight="@id/rvTorrentList"
+            android:nextFocusDown="@id/rvTorrentList"
             android:tooltipText="@string/refresh"
             app:icon="@drawable/icon_reload"
             app:iconSize="25dp" />
@@ -104,6 +104,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
+            android:nextFocusUp="@id/cbSelectAll"
             android:scrollbars="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintTop_toBottomOf="@id/llMultiSelection"

--- a/app/app/src/main/res/layout/custom_chip_layout.xml
+++ b/app/app/src/main/res/layout/custom_chip_layout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.chip.Chip xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/Widget.Material3.Chip.Filter.Elevated"
+    style="@style/Widget.Unchained.Chip.FilterElevated"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content" />

--- a/app/app/src/main/res/layout/dialog_manage_repository.xml
+++ b/app/app/src/main/res/layout/dialog_manage_repository.xml
@@ -8,7 +8,7 @@
     android:layout_height="wrap_content"
     tools:ignore="HardcodedText">
 
-    <androidx.core.widget.NestedScrollView
+    <com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:orientation="vertical">
@@ -178,5 +178,5 @@
                 app:layout_constraintTop_toBottomOf="@id/bUninstallRepo" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.core.widget.NestedScrollView>
+    </com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView>
 </LinearLayout>

--- a/app/app/src/main/res/layout/dialog_service_picker.xml
+++ b/app/app/src/main/res/layout/dialog_service_picker.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -26,4 +26,4 @@
             tools:listitem="@layout/item_list_kodi_device" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.core.widget.NestedScrollView>
+</com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView>

--- a/app/app/src/main/res/layout/fragment_complete_service.xml
+++ b/app/app/src/main/res/layout/fragment_complete_service.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -207,4 +207,4 @@
         </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.core.widget.NestedScrollView>
+</com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView>

--- a/app/app/src/main/res/layout/fragment_download_details.xml
+++ b/app/app/src/main/res/layout/fragment_download_details.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -139,6 +139,7 @@
                     android:id="@+id/fabShareLink"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:focusable="true"
                     android:contentDescription="@string/share"
                     app:srcCompat="@drawable/icon_share" />
 
@@ -164,6 +165,7 @@
                     android:id="@+id/fabOpenLink"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:focusable="true"
                     android:contentDescription="@string/open_link"
                     app:srcCompat="@drawable/icon_open_external" />
 
@@ -189,6 +191,7 @@
                     android:id="@+id/fabCopyLink"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:focusable="true"
                     android:contentDescription="@string/copy_link"
                     app:srcCompat="@drawable/icon_copy" />
 
@@ -214,6 +217,7 @@
                     android:id="@+id/fabDownloadLink"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:focusable="true"
                     android:contentDescription="@string/download"
                     app:srcCompat="@drawable/icon_download" />
 
@@ -238,6 +242,7 @@
                     android:id="@+id/fabSendToPlayer"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:focusable="true"
                     android:contentDescription="@string/send_to_player"
                     app:srcCompat="@drawable/icon_play_local" />
 
@@ -263,6 +268,7 @@
                     android:id="@+id/fabPickStreaming"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:focusable="true"
                     android:contentDescription="@string/streaming"
                     app:srcCompat="@drawable/icon_remote" />
 
@@ -315,6 +321,7 @@
                     android:id="@+id/fabLoadStreams"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:focusable="true"
                     android:contentDescription="@string/load_streams"
                     app:srcCompat="@drawable/icon_transform" />
 
@@ -347,4 +354,4 @@
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.core.widget.NestedScrollView>
+</com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView>

--- a/app/app/src/main/res/layout/fragment_downloads_list.xml
+++ b/app/app/src/main/res/layout/fragment_downloads_list.xml
@@ -58,10 +58,22 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/share"
-            android:nextFocusRight="@id/rvDownloadList"
+            android:nextFocusRight="@id/bRefresh"
             android:nextFocusDown="@id/rvDownloadList"
             android:tooltipText="@string/share_selected"
             app:icon="@drawable/icon_share"
+            app:iconSize="25dp" />
+
+        <Button
+            android:id="@+id/bRefresh"
+            style="?attr/materialIconButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/refresh"
+            android:nextFocusRight="@id/rvDownloadList"
+            android:nextFocusDown="@id/rvDownloadList"
+            android:tooltipText="@string/refresh"
+            app:icon="@drawable/icon_reload"
             app:iconSize="25dp" />
 
     </LinearLayout>
@@ -80,6 +92,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
+            android:nextFocusUp="@id/cbSelectAll"
             android:scrollbars="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/item_list_download" />

--- a/app/app/src/main/res/layout/fragment_remote_service.xml
+++ b/app/app/src/main/res/layout/fragment_remote_service.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -236,4 +236,4 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.card.MaterialCardView>
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.core.widget.NestedScrollView>
+</com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView>

--- a/app/app/src/main/res/layout/fragment_search_plugins_tab.xml
+++ b/app/app/src/main/res/layout/fragment_search_plugins_tab.xml
@@ -55,7 +55,7 @@
 
     <Button
         android:id="@+id/bStartSearch"
-        style="@style/Widget.Material3.Button.OutlinedButton"
+        style="@style/Widget.Unchained.Button.Outlined"
         android:layout_marginTop="5dp"
         android:layout_width="250dp"
         android:layout_height="wrap_content"

--- a/app/app/src/main/res/layout/fragment_torrent_details.xml
+++ b/app/app/src/main/res/layout/fragment_torrent_details.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.core.widget.NestedScrollView
+<com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -48,6 +48,7 @@
                     android:id="@+id/fabShareMagnet"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:focusable="true"
                     android:contentDescription="@string/share_magnet"
                     app:srcCompat="@drawable/icon_share" />
 
@@ -72,6 +73,7 @@
                     android:id="@+id/fabCopyMagnet"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:focusable="true"
                     android:contentDescription="@string/copy_magnet"
                     app:srcCompat="@drawable/icon_open_external" />
 
@@ -402,4 +404,4 @@
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
     </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+</com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView>

--- a/app/app/src/main/res/layout/fragment_torrent_processing.xml
+++ b/app/app/src/main/res/layout/fragment_torrent_processing.xml
@@ -134,7 +134,10 @@
         android:layout_gravity="bottom|end"
         android:layout_marginEnd="15dp"
         android:layout_marginBottom="15dp"
+        android:focusable="true"
         android:contentDescription="@string/download"
+        android:nextFocusLeft="@id/rvTorrentFilePicker"
+        android:nextFocusUp="@id/rvTorrentFilePicker"
         app:srcCompat="@drawable/icon_download" />
 
 </FrameLayout>

--- a/app/app/src/main/res/layout/fragment_torrents_list.xml
+++ b/app/app/src/main/res/layout/fragment_torrents_list.xml
@@ -25,6 +25,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="false"
+            android:nextFocusDown="@id/rvTorrentList"
             android:text="0"
             android:tooltipText="@string/select_deselect_all" />
 
@@ -34,6 +35,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/delete"
+            android:nextFocusDown="@id/rvTorrentList"
             android:tooltipText="@string/delete_selected"
             app:icon="@drawable/icon_delete"
             app:iconSize="25dp" />
@@ -44,6 +46,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/download"
+            android:nextFocusDown="@id/rvTorrentList"
             android:tooltipText="@string/download_selected"
             app:icon="@drawable/icon_download"
             app:iconSize="25dp" />
@@ -54,8 +57,22 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:contentDescription="@string/torrent_details"
+            android:nextFocusRight="@id/bRefresh"
+            android:nextFocusDown="@id/rvTorrentList"
             android:tooltipText="@string/torrent_details"
             app:icon="@drawable/icon_info"
+            app:iconSize="25dp" />
+
+        <Button
+            android:id="@+id/bRefresh"
+            style="?attr/materialIconButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/refresh"
+            android:nextFocusRight="@id/rvTorrentList"
+            android:nextFocusDown="@id/rvTorrentList"
+            android:tooltipText="@string/refresh"
+            app:icon="@drawable/icon_reload"
             app:iconSize="25dp" />
 
     </LinearLayout>
@@ -74,6 +91,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
+            android:nextFocusUp="@id/cbSelectAll"
             android:scrollbars="vertical"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintTop_toBottomOf="@id/llMultiSelection"

--- a/app/app/src/main/res/layout/fragment_user_profile.xml
+++ b/app/app/src/main/res/layout/fragment_user_profile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -164,7 +164,7 @@
 
         <Button
             android:id="@+id/bAccount"
-            style="@style/Widget.Material3.Button"
+            style="@style/Widget.Unchained.Button"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
@@ -177,7 +177,7 @@
 
         <Button
             android:id="@+id/bSettings"
-            style="@style/Widget.Material3.Button"
+            style="@style/Widget.Unchained.Button"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginStart="20dp"
@@ -189,4 +189,4 @@
             app:layout_constraintTop_toTopOf="@id/bAccount" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.core.widget.NestedScrollView>
+</com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView>

--- a/app/app/src/main/res/layout/item_list_download.xml
+++ b/app/app/src/main/res/layout/item_list_download.xml
@@ -12,7 +12,9 @@
     android:focusable="true"
     android:padding="10dp"
     app:cardCornerRadius="10dp"
-    app:cardElevation="3dp">
+    app:cardElevation="3dp"
+    app:strokeColor="@color/list_card_stroke"
+    app:strokeWidth="@dimen/focus_stroke_width">
 
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/app/src/main/res/layout/item_list_search.xml
+++ b/app/app/src/main/res/layout/item_list_search.xml
@@ -12,7 +12,9 @@
     android:focusable="true"
     android:padding="10dp"
     app:cardCornerRadius="10dp"
-    app:cardElevation="3dp">
+    app:cardElevation="3dp"
+    app:strokeColor="@color/list_card_stroke"
+    app:strokeWidth="@dimen/focus_stroke_width">
 
 
     <LinearLayout

--- a/app/app/src/main/res/layout/item_list_torrent.xml
+++ b/app/app/src/main/res/layout/item_list_torrent.xml
@@ -13,7 +13,9 @@
     android:checkable="false"
     android:focusable="true"
     app:cardCornerRadius="10dp"
-    app:cardElevation="3dp">
+    app:cardElevation="3dp"
+    app:strokeColor="@color/list_card_stroke"
+    app:strokeWidth="@dimen/focus_stroke_width">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/app/src/main/res/layout/item_list_torrent_file.xml
+++ b/app/app/src/main/res/layout/item_list_torrent_file.xml
@@ -4,7 +4,9 @@
     android:id="@+id/file_list_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="10dp">
+    android:layout_marginBottom="10dp"
+    android:background="?attr/selectableItemBackground"
+    android:focusable="true">
 
     <TextView
         android:id="@+id/tvFileID"

--- a/app/app/src/main/res/layout/item_list_torrent_selection_directory.xml
+++ b/app/app/src/main/res/layout/item_list_torrent_selection_directory.xml
@@ -9,6 +9,7 @@
         android:id="@+id/cbSelectDirectory"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:nextFocusRight="@id/fabDownload"
         android:text=""
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/ivIcon"

--- a/app/app/src/main/res/layout/item_list_torrent_selection_file.xml
+++ b/app/app/src/main/res/layout/item_list_torrent_selection_file.xml
@@ -12,6 +12,7 @@
         android:id="@+id/cbSelectFile"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:nextFocusRight="@id/fabDownload"
         android:text=""
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/tvFileName"

--- a/app/app/src/main/res/layout/item_theme_list.xml
+++ b/app/app/src/main/res/layout/item_theme_list.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
+    android:focusable="true"
     android:minHeight="56dp"
     android:paddingHorizontal="20dp"
     android:paddingVertical="12dp">

--- a/app/app/src/main/res/layout/new_download_fragment.xml
+++ b/app/app/src/main/res/layout/new_download_fragment.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -172,4 +172,4 @@
             app:layout_constraintTop_toBottomOf="@+id/tvUploadTorrent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</androidx.core.widget.NestedScrollView>
+</com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView>

--- a/app/app/src/main/res/layout/sidesheet_search_plugins_options.xml
+++ b/app/app/src/main/res/layout/sidesheet_search_plugins_options.xml
@@ -107,7 +107,7 @@
                 android:textAppearance="?attr/textAppearanceTitleMedium" />
 
             <!-- todo: decide max height, change to fill available height on horizontal. Also decide max width for sheet -->
-            <androidx.core.widget.NestedScrollView
+            <com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
@@ -120,13 +120,13 @@
 
                     <com.google.android.material.chip.Chip
                         android:id="@+id/allPluginsChip"
-                        style="@style/Widget.Material3.Chip.Filter.Elevated"
+                        style="@style/Widget.Unchained.Chip.FilterElevated"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:checked="false"
                         android:text="@string/all" />
                 </com.google.android.material.chip.ChipGroup>
-            </androidx.core.widget.NestedScrollView>
+            </com.github.livingwithhippos.unchained.utilities.NonFocusableNestedScrollView>
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 </LinearLayout>

--- a/app/app/src/main/res/values-night/themes.xml
+++ b/app/app/src/main/res/values-night/themes.xml
@@ -4,6 +4,19 @@
         <item name="toolbarStyle">@style/Widget.App.Toolbar</item>
         <!-- this can be used to customize backgrounds with images, otherwise it will use the default android:colorBackground value -->
         <item name="mainBackground">@drawable/bg_solid</item>
+
+        <!-- keep in sync with values/themes.xml: focused ring styles for d-pad navigation -->
+        <item name="materialButtonStyle">@style/Widget.Unchained.Button</item>
+        <item name="materialButtonOutlinedStyle">@style/Widget.Unchained.Button.Outlined</item>
+        <item name="borderlessButtonStyle">@style/Widget.Unchained.Button.Text</item>
+        <item name="materialIconButtonStyle">@style/Widget.Unchained.Button.Icon</item>
+        <item name="materialIconButtonFilledStyle">@style/Widget.Unchained.Button.IconFilled</item>
+        <item name="floatingActionButtonStyle">@style/Widget.Unchained.FloatingActionButton</item>
+        <item name="checkboxStyle">@style/Widget.Unchained.CheckBox</item>
+        <item name="materialSwitchStyle">@style/Widget.Unchained.Switch</item>
+        <item name="actionButtonStyle">@style/Widget.Unchained.ActionButton</item>
+        <item name="actionOverflowButtonStyle">@style/Widget.Unchained.ActionButton.Overflow</item>
+        <item name="toolbarNavigationButtonStyle">@style/Widget.Unchained.ActionButton.Navigation</item>
     </style>
 
 

--- a/app/app/src/main/res/values-v21/dimens.xml
+++ b/app/app/src/main/res/values-v21/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- see values/dimens.xml: the material library redefines this token per API level
+    (values-v21 and values-v28), and those buckets would shadow the base override -->
+    <item name="m3_sys_state_focus_state_layer_opacity" type="dimen">0.35</item>
+</resources>

--- a/app/app/src/main/res/values-v28/dimens.xml
+++ b/app/app/src/main/res/values-v28/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- see values/dimens.xml: the material library redefines this token per API level
+    (values-v21 and values-v28), and those buckets would shadow the base override -->
+    <item name="m3_sys_state_focus_state_layer_opacity" type="dimen">0.35</item>
+</resources>

--- a/app/app/src/main/res/values/dimens.xml
+++ b/app/app/src/main/res/values/dimens.xml
@@ -5,4 +5,12 @@
     <dimen name="stat_card_elevation">10dp</dimen>
     <dimen name="custom_color_swatch_size">44dp</dimen>
     <dimen name="custom_color_swatch_margin">12dp</dimen>
+    <dimen name="focus_stroke_width">3dp</dimen>
+
+    <!-- Overrides the Material 3 focused state layer opacity token (default 0.1), which every
+    Material widget's ripple color state list resolves its state_focused alpha through: buttons,
+    icon buttons, FABs, checkboxes, chips, navigation bar items, tabs. 0.1 is nearly invisible
+    when navigating with a d-pad on a TV, so raise it to a clearly visible overlay. Pressed,
+    hovered and resting states keep their own tokens, so nothing changes for touch users. -->
+    <item name="m3_sys_state_focus_state_layer_opacity" type="dimen">0.35</item>
 </resources>

--- a/app/app/src/main/res/values/themes.xml
+++ b/app/app/src/main/res/values/themes.xml
@@ -5,6 +5,96 @@
         <item name="toolbarStyle">@style/Widget.App.Toolbar</item>
         <!-- this can be used to customize backgrounds with images, otherwise it will use the default android:colorBackground value -->
         <item name="mainBackground">@drawable/bg_solid</item>
+
+        <!-- interactive controls draw a colored ring while focused so that d-pad navigation on
+        Android TV is always visible; the ring is a foreground overlay, invisible unless the
+        view is focused, so nothing changes for touch users -->
+        <item name="materialButtonStyle">@style/Widget.Unchained.Button</item>
+        <item name="materialButtonOutlinedStyle">@style/Widget.Unchained.Button.Outlined</item>
+        <item name="borderlessButtonStyle">@style/Widget.Unchained.Button.Text</item>
+        <item name="materialIconButtonStyle">@style/Widget.Unchained.Button.Icon</item>
+        <item name="materialIconButtonFilledStyle">@style/Widget.Unchained.Button.IconFilled</item>
+        <item name="floatingActionButtonStyle">@style/Widget.Unchained.FloatingActionButton</item>
+        <item name="checkboxStyle">@style/Widget.Unchained.CheckBox</item>
+        <item name="materialSwitchStyle">@style/Widget.Unchained.Switch</item>
+        <item name="actionButtonStyle">@style/Widget.Unchained.ActionButton</item>
+        <item name="actionOverflowButtonStyle">@style/Widget.Unchained.ActionButton.Overflow</item>
+        <item name="toolbarNavigationButtonStyle">@style/Widget.Unchained.ActionButton.Navigation</item>
+    </style>
+
+    <!-- focused ring variants of the material widget styles, see the main theme.
+
+    Material3's button styles all bake in a 4dp android:insetTop/Bottom (icon buttons add
+    insetLeft/Right too), which shrinks the button's own drawn surface inward from the view's
+    full bounds; the focus ring above is a foreground drawn to those full bounds. Left alone,
+    a focused button shows a gap between its own edge and the ring's stroke (the view's
+    background showing through) with the ring's stroke floating just outside it. Zeroing the
+    insets here makes the button's surface fill the view completely, so the ring actually hugs
+    it. -->
+    <style name="Widget.Unchained.Button" parent="Widget.Material3.Button">
+        <item name="android:foreground">@drawable/focus_ring_pill</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+    </style>
+
+    <style name="Widget.Unchained.Button.Outlined" parent="Widget.Material3.Button.OutlinedButton">
+        <item name="android:foreground">@drawable/focus_ring_pill</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+    </style>
+
+    <style name="Widget.Unchained.Button.Text" parent="Widget.Material3.Button.TextButton">
+        <item name="android:foreground">@drawable/focus_ring_pill</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+    </style>
+
+    <style name="Widget.Unchained.Button.Icon" parent="Widget.Material3.Button.IconButton">
+        <item name="android:foreground">@drawable/focus_ring_pill</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="android:insetLeft">0dp</item>
+        <item name="android:insetRight">0dp</item>
+    </style>
+
+    <style name="Widget.Unchained.Button.IconFilled" parent="Widget.Material3.Button.IconButton.Filled">
+        <item name="android:foreground">@drawable/focus_ring_pill</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="android:insetLeft">0dp</item>
+        <item name="android:insetRight">0dp</item>
+    </style>
+
+    <style name="Widget.Unchained.FloatingActionButton" parent="Widget.Material3.FloatingActionButton.Primary">
+        <item name="android:foreground">@drawable/focus_ring_fab</item>
+    </style>
+
+    <style name="Widget.Unchained.CheckBox" parent="Widget.Material3.CompoundButton.CheckBox">
+        <item name="android:foreground">@drawable/focus_ring_control</item>
+    </style>
+
+    <style name="Widget.Unchained.Switch" parent="Widget.Material3.CompoundButton.MaterialSwitch">
+        <item name="android:foreground">@drawable/focus_ring_control</item>
+    </style>
+
+    <style name="Widget.Unchained.Chip.FilterElevated" parent="Widget.Material3.Chip.Filter.Elevated">
+        <item name="android:foreground">@drawable/focus_ring_control</item>
+    </style>
+
+    <!-- toolbar action icons, the overflow button and the navigation (back/up) icon all sit
+    directly on colorPrimary, so they get their own on-primary ring instead of the general
+    focus_ring_pill one; without this the back arrow had no focus indicator at all, unlike its
+    neighboring overflow button -->
+    <style name="Widget.Unchained.ActionButton" parent="Widget.AppCompat.ActionButton">
+        <item name="android:foreground">@drawable/focus_ring_toolbar</item>
+    </style>
+
+    <style name="Widget.Unchained.ActionButton.Overflow" parent="Widget.AppCompat.ActionButton.Overflow">
+        <item name="android:foreground">@drawable/focus_ring_toolbar</item>
+    </style>
+
+    <style name="Widget.Unchained.ActionButton.Navigation" parent="Widget.AppCompat.Toolbar.Button.Navigation">
+        <item name="android:foreground">@drawable/focus_ring_toolbar</item>
     </style>
 
     <!-- no custom colors: DynamicColors overlays these at runtime, either from the wallpaper or


### PR DESCRIPTION
Every interactive control now draws a colored ring while focused, since there was often no visible feedback for where the remote's selection currently was. Covers buttons, FABs, checkboxes, list item cards and the toolbar's back and overflow icons.

A number of controls were not actually reachable with the d-pad in the first place. FloatingActionButtons across the app were clickable but never focusable. NestedScrollView also claims focus for itself in its own constructor, which hid the real content underneath it, so scrolling screens now use a small NonFocusableNestedScrollView instead.

This also fixes the two remote issues described in #376: pressing back while focus is inside a long list now moves focus to the bottom navigation bar instead of doing nothing, and the landscape torrents list's refresh button can now be reached with the d-pad (its nextFocusDown pointed at a view id that does not exist in that layout).

Bundled in is one small unrelated fix: a refresh button was missing from the portrait downloads and torrents lists, already present in landscape.

Validated on a real Google TV Streamer, but this touches a lot of screens so more testing and review is welcome.

Related to #376
Related to #452